### PR TITLE
Improvements to the buildovj script.

### DIFF
--- a/bin/buildovj
+++ b/bin/buildovj
@@ -70,8 +70,13 @@ gitSSH=''
 # If gitSSH is an empty string, the gitURL is used
 # If you plan to commit changes to the OpenVnmrJ project,
 # use should use the ssh protocol on your fork of the OpenVnmrJ project.
-# Replace the two userName strings in gitSSH with your github account name.
-# gitSSH='ssh://userName@github.com/userName/OpenVnmrJ.git'
+# Replace the userName string in gitSSH with your github account name.
+# gitSSH='ssh://git@github.com/userName/OpenVnmrJ.git'
+
+gitBranch='master'
+# If you plan to commit changes, you should commit them to the development branch.
+# If you just want to build the latest official release, build from the master branch.
+# gitBranch='development'
 
 doScons=yes
 buildOVJ=yes    # Build for Direct-Drive (VnmrS/DD2/ProPulse)
@@ -96,6 +101,6 @@ then
 fi
 ovjLogFile=$ovjBuildDir/logs/makeovj.$date
 cd $ovjBuildDir
-export ovjBuildDir workspacedir OVJ_TOOLS dvdCopyDir1 dvdCopyDir2 dvdBuildName1 dvdBuildName2 dvdCopyName1 dvdCopyName2 ovjLogFile doScons doGitClone mail_list gitURL gitSSH ovjAppName buildOVJ buildOVJMI sconsJoption osxflags
+export ovjBuildDir workspacedir OVJ_TOOLS dvdCopyDir1 dvdCopyDir2 dvdBuildName1 dvdBuildName2 dvdCopyName1 dvdCopyName2 ovjLogFile doScons doGitClone mail_list gitURL gitSSH gitBranch ovjAppName buildOVJ buildOVJMI sconsJoption osxflags
 $ovjBuildDir/bin/makeovj > $ovjLogFile 2>&1
 

--- a/bin/makeovj
+++ b/bin/makeovj
@@ -50,10 +50,11 @@ then
        echo "===>>> $date Clone OpenVnmrJ (ssh) <<<==="
        git clone ${gitSSH}
     fi
-# To build from a branch, uncomment the next three lines, altering branch as needed
-#   cd $buildDir/OpenVnmrJ
-#   git branch --track VnmrJ_3.1 origin/VnmrJ_3.1
-#   git checkout VnmrJ_3.1
+    if [ x$gitBranch != "x" -a x$gitBranch != "xmaster" ]
+    then
+       cd $buildDir/OpenVnmrJ
+       git checkout $gitBranch
+    fi
   fi
   if [ x$doGitClone = "xpull" ]
   then


### PR DESCRIPTION
The ssh clone uses git@github.com instead of username@github.com.
Also, buildovj can now specify the branch (e.g., master or development)
to build. The default is to use a https and to build the master branch.