### PR TITLE
Updates for VM build scripts.

### DIFF
--- a/bin/loglib.sh
+++ b/bin/loglib.sh
@@ -1,0 +1,144 @@
+#
+# Copyright (C) 2018  Michael Tesch
+#
+# This file is a part of the OpenVnmrJ project.  You may distribute it
+# under the terms of either the GNU General Public License or the
+# Apache 2.0 License, as specified in the LICENSE file.
+#
+# For more information, see the OpenVnmrJ LICENSE file.
+#
+
+# this is a shell-function library.  To use the functions
+# in your shell script, first include this by "sourceing"
+# this file:
+# 'source loglib.sh' or '. loglib.sh'
+# The latter syntax with '.' is POSIX.
+#
+# CMDLINE="$0 $*"
+# SCRIPT=$(basename "$0")
+# SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+#
+
+: ${CMDLINE=loglib.sh}
+: ${VERBOSE=3}
+: ${ERRCOUNT=0}
+
+LEVELNAMES=( ERROR "MSG  " "WARN " "INFO " DEBUG )
+
+# call this before calling any log commands.  can be called repeatedly
+# from one script to change the log file.
+log_setup () {
+    # directory for log files, will try
+    # to mkdir -p if non-existant
+    local logdir="$2"
+    [ -z "$logdir" ] && logdir=.
+    LOGFILE="${logdir}/$1"       # typically $(basename "$0" .sh).txt
+
+    # colors & names of the log levels
+    # check if stdout is a terminal...
+    if test -t 1; then
+        # see if it supports colors...
+        ncolors=$(tput colors)
+        if test -n "$ncolors" && test "$ncolors" -ge 8; then
+            normal="$(tput sgr0)"
+            bold="$(tput bold)"
+            red="$(tput setaf 1)"
+            green="$(tput setaf 2)"
+            yellow="$(tput setaf 3)"
+            cyan="$(tput setaf 6)"
+            white="$(tput setaf 7)"
+            magenta="$(tput setaf 5)"
+        fi
+    fi
+    #set -x
+    LEVELCOLOR=( "$red" "$white$bold" "$yellow" "$green" "$cyan" )
+
+    if [ ! -d "$logdir" ]; then
+        echo "creating log directory '$logdir'"
+        mkdir -p "$logdir" || return $?
+    fi
+    if [ ! -d "$logdir" ]; then
+        echo "${red}Unable to create log directory '$logdir':${normal}"
+        echo "  ${red}log messages will be printed to the terminal.${normal}"
+        return
+    fi
+    if [ -t 3 ] && [ -t 4 ]; then
+        # restore stdin and stdout before opening new logfile
+        exec 1>&3 2>&4
+    fi
+    exec 3>&1 4>&2
+    trap 'exec 1>&3 2>&4' 0
+    trap 'exec 1>&3 2>&4; exit 1' 1 2 3
+    #trap 'onerror' 0 1 2 3
+    if [ ${VERBOSE} -gt 3 ]; then
+        # at VERBOSE >= DEBUG level, also send cmd output to terminal
+        exec 1> >(tee -a "${LOGFILE}") 2>&1
+    else
+        exec 1> "$LOGFILE" 2>&1
+    fi
+    # how & when this script was called
+    log_debug " $CMDLINE"
+    log_info "Logfile: $LOGFILE"
+}
+log_msg_ () {
+    local level=$1
+    shift
+    #local datestring=$(date +"%Y-%m-%d %H:%M:%S")
+    local message="$*"
+    echo "${LEVELCOLOR[level]}${LEVELNAMES[level]}:${message}${normal}"
+    if [ -t 3 ] && [ ${VERBOSE} -le 3 ] && [ "$level" -le ${VERBOSE} ]; then
+        echo "${LEVELCOLOR[level]}${LEVELNAMES[level]}:${message}${normal}" >&3
+    fi
+}
+log_error () { log_msg_ 0 "$*" ; ERRCOUNT=$(( ERRCOUNT + 1 )) ; }
+log_msg   () { log_msg_ 1 "$*" ; }
+log_warn  () { log_msg_ 2 "$*" ; }
+log_info  () { log_msg_ 3 "$*" ; }
+log_debug () { log_msg_ 4 "$*" ; }
+log_cmd   () { log_info "\$ $*" ; "$@" ; }
+cmdspin () {
+    #
+    # Run a command, spin a wheelie while it's running
+    #
+    local start=$SECONDS
+    log_info "Cmd started $(date)"
+    log_info "\$ $*"
+    # spinner
+    local sp='/-\|'
+    if [ -t 3 ]; then printf ' ' >&3 ; fi
+    while : ; do
+        sleep 1;
+        sp=${sp#?}${sp%???}
+        if [ -t 3 ]; then printf '\b%.1s' "$sp" >&3 ; fi
+    done &
+    SPINNER_PID=$!
+    # Kill the spinner if we die prematurely
+    trap "kill $SPINNER_PID" EXIT
+    # command runs here
+    "$@"
+    retval=$?
+    # Kill the loop and unset the EXIT trap
+    kill -PIPE $SPINNER_PID
+    trap " " EXIT
+    if [ -t 3 ]; then printf '\b.\n' >&3 ; fi
+    local dur=$(( $SECONDS - $start ))
+    log_info "Cmd returned: $retval, duration: $(TZ=UTC0 printf '%(%H:%M:%S)T\n' "$dur")"
+    return $retval
+}
+
+if [ x$LOGLIBTEST = y ]; then
+    log_warn "bad"
+    log_msg "bold"
+    log_info "info"
+    log_error "error"
+    log_debug "debug"
+    log_setup "lib.log1"
+    log_warn "hello1"
+    log_setup "lib.log2"
+    log_warn "hello2"
+    log_warn "bad"
+    log_msg "bold"
+    log_info "info"
+    log_error "error"
+    log_debug "debug"
+fi

--- a/vms/box_defs/centos6/Vagrantfile
+++ b/vms/box_defs/centos6/Vagrantfile
@@ -10,7 +10,7 @@
 #
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "bento/centos-6.8"
+  config.vm.box = "bento/centos-6.10"
   #config.vm.box_version = "2.2.9"
   #config.vm.box = "centos/6"
   #config.vm.box_version = "1608.02"
@@ -19,8 +19,8 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |vb|
     #vb.gui = true
     vb.linked_clone = true
-    vb.memory = "4096"
-    vb.cpus = 2
+    vb.memory = "8192"
+    vb.cpus = 4
     vb.customize "pre-boot", ["storageattach", :id,
                               "--storagectl", "IDE Controller",
                               "--port", "1",
@@ -30,24 +30,30 @@ Vagrant.configure("2") do |config|
                              ]
   end
   config.vm.provision "shell", inline: <<-SHELL
+    set -e
     yum install -y epel-release
     yum update -y # this hoses the guest additions, install vagrant vbguest to workaround
 
     # these are needed to build
-    yum install -y git scons zip unzip gcc-gfortran gcc-c++ mesa-libGL-devel mesa-libGLU-devel
-    yum install -y glibc-devel.i686 libstdc++.i686 libX11-devel.i686 libXt-devel.i686 openmotif-devel.i686
-    yum install -y gsl-devel
+    yum install -y git scons zip unzip gcc-gfortran gcc-c++ mesa-libGL-devel \
+        mesa-libGLU-devel gsl-devel libtiff-devel
+    yum install -y glibc-devel.i686 libstdc++.i686 libX11-devel.i686 \
+        libXt-devel.i686 openmotif-devel.i686
 
     # these are needed to install
     yum -y groupinstall "Desktop"
-    sudo yum install -y gdb libtool automake autoconf expect rsh-server xinetd tftp-server strace tcsh
-    sudo yum install -y libXext-devel.i686
-    sudo yum install -y kernel-devel compat-libf2c-34 compat-gcc-34-g77 openmotif22
-    sudo yum install -y mutt sendmail-cf k3b ghostscript ImageMagick rsh libXtst-devel.i686
-    sudo yum install -y libXi.i686 libstdc++-devel.i686 ncurses-libs.i686 ncurses-devel.i686
-    sudo yum install -y mesa-libGL-devel.i686
-    sudo yum install -y atk.i686 gtk2.i686 mesa-libGL.i686
-    sudo yum install -y mesa-libGLU.i686 libidn.i686 libxml2.i686 libXaw.i686 libXpm.i686
+    yum install -y gdb libtool automake autoconf expect rsh-server xinetd \
+         tftp-server strace tcsh xterm gnuplot cups mutt sendmail-cf k3b \
+         ghostscript ImageMagick rsh kernel-devel openmotif22 compat-libf2c-34 \
+         compat-gcc-34-g77 dos2unix enscript gedit
+    yum install -y libXext-devel.i686 libXtst-devel.i686 \
+         libXi.i686 libstdc++-devel.i686 ncurses-libs.i686 ncurses-devel.i686 \
+         mesa-libGL-devel.i686 \
+         atk.i686 gtk2.i686 mesa-libGL.i686 \
+         mesa-libGLU.i686 libidn.i686 libxml2.i686 libXaw.i686 libXpm.i686
+
+    # enable graphical boot
+    sed -i -e 's/id:3:initdefault/id:5:initdefault/' /etc/inittab
 
     yum clean all
     # disable SELinux

--- a/vms/box_defs/centos7/Vagrantfile
+++ b/vms/box_defs/centos7/Vagrantfile
@@ -10,7 +10,8 @@
 #
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "centos/7"
+  #config.vm.box = "centos/7"
+  config.vm.box = "bento/centos-7.5"
   #config.vm.box_version = "?"
   config.ssh.insert_key = false # only needed for vagrant 1.8.5 #7610
   config.vm.synced_folder '.', '/vagrant', disabled: true
@@ -18,29 +19,31 @@ Vagrant.configure("2") do |config|
     # Display the VirtualBox GUI when booting the machine
     #vb.gui = true
     vb.linked_clone = true
-    vb.memory = "4096"
-    vb.cpus = 2
+    vb.memory = "8192"
+    vb.cpus = 4
   end
   config.vm.provision "shell", inline: <<-SHELL
+    set -e
     yum install -y epel-release
     yum update -y # this hoses the guest additions, install vagrant vbguest to workaround
 
     # these are needed to build
-    yum install -y git scons zip unzip gcc-gfortran gcc-c++ mesa-libGL-devel mesa-libGLU-devel
-    yum install -y glibc-devel.i686 libstdc++.i686 libX11-devel.i686 libXt-devel.i686 motif-devel.i686
-    yum install -y git scons gcc-gfortran gcc-c++
-    yum install -y gsl-devel
+    yum install -y git scons zip unzip gcc-gfortran gcc-c++ gsl-devel \
+        mesa-libGL-devel mesa-libGLU-devel libtiff-devel
+    yum install -y glibc-devel.i686 libstdc++.i686 libX11-devel.i686 \
+        libXt-devel.i686 motif-devel.i686
 
     # these are needed to install
-    yum -y groupinstall "Desktop"
-    yum install -y gdb libtool automake autoconf expect rsh-server xinetd tftp-server strace tcsh
-    yum install -y libXext-devel.i686
-    yum install -y kernel-devel
-    yum install -y mutt sendmail-cf k3b ghostscript ImageMagick rsh libXtst-devel.i686
-    yum install -y libXi.i686 libstdc++-devel.i686 ncurses-libs.i686 ncurses-devel.i686
-    yum install -y mesa-libGL-devel.i686
-    yum install -y atk.i686 gtk2.i686 mesa-libGL.i686
-    yum install -y mesa-libGLU.i686 libidn.i686 libxml2.i686 libXaw.i686 libXpm.i686
+    yum -y groupinstall "GNOME Desktop"
+    yum install -y gdb libtool automake autoconf expect rsh-server xinetd \
+        tftp-server strace tcsh kernel-devel compat-libf2c-34 \
+        mutt sendmail-cf k3b ghostscript ImageMagick rsh cups gedit \
+        dos2unix gnuplot xterm enscript
+    yum install -y libXtst-devel.i686 libXext-devel.i686 libXi.i686 \
+        libstdc++-devel.i686 ncurses-libs.i686 ncurses-devel.i686 \
+        mesa-libGL-devel.i686 \
+        atk.i686 gtk2.i686 mesa-libGL.i686 \
+        mesa-libGLU.i686 libidn.i686 libxml2.i686 libXaw.i686 libXpm.i686
 
     systemctl set-default graphical.target
     systemctl start graphical.target

--- a/vms/box_defs/macos10.10/Vagrantfile
+++ b/vms/box_defs/macos10.10/Vagrantfile
@@ -17,28 +17,14 @@ Vagrant.configure("2") do |config|
     #vb.gui = true
     # Customize the amount of memory on the VM:
     vb.linked_clone = true
-    vb.memory = "4096"
-    #vb.cpus = 2
-
-    unless File.exist?('tmp2.vmdk')
-      vb.customize ['createhd', '--filename', 'tmp2.vmdk', '--size', 20*1024, '--format', 'vmdk' ]
-    end
-    vb.customize ['storageattach', :id,
-                  '--storagectl', 'SATA',
-                  '--port', 4,
-                  '--device', 0,
-                  '--type', 'hdd',
-                  '--medium', 'tmp2.vmdk']
-
+    vb.memory = "8192"
+    vb.cpus = 4
   end
-
-  # create a case-sensitive filesystem on the vmdk from above
-  config.vm.provision "shell", inline: <<-SHELL
-    diskutil eraseDisk jhfsx Vagrant1 /dev/disk1
-  SHELL
 
   # brew runs as a user
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    set -e
+    brew update
     brew install scons postgres
   SHELL
 end

--- a/vms/box_defs/ubuntu14/Vagrantfile
+++ b/vms/box_defs/ubuntu14/Vagrantfile
@@ -17,30 +17,34 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |vb|
     #vb.gui = true
     vb.linked_clone = true
-    vb.memory = "2048"
-    vb.cpus = 2
+    vb.memory = "8192"
+    vb.cpus = 4
   end
   config.vm.provision "shell", inline: <<-SHELL
     export DEBIAN_FRONTEND=noninteractive
+    set -e
     dpkg --add-architecture i386
     apt-get -qq update
     apt-get -qq -y dist-upgrade
 
     # these are needed to build
-    apt-get install -y git scons
-    apt-get install -y g++ gfortran
-    apt-get install -y lib32stdc++-4.8-dev libc6-dev-i386 libglu1-mesa-dev
+    apt-get install -y git scons g++ gfortran lib32stdc++-4.8-dev \
+            libc6-dev-i386 libglu1-mesa-dev libgsl0-dev libtiff5-dev
     apt-get install -y libmotif-dev:i386 libx11-dev:i386 libxt-dev:i386
 
     # these are needed to install
-    apt-get install -y openjdk-6-jre csh expect
-    apt-get install -y rsh-server tftpd mutt sharutils gnome-power-manager k3b kdiff3 rarpd
+    #apt-get install -y openjdk-6-jre
+    apt-get install -y csh expect rsh-server tftpd mutt sharutils \
+            gnome-power-manager k3b kdiff3 rarpd
 
     #debconf-set-selections <<< "postfix postfix/mailname string your.hostname.com"
     #debconf-set-selections <<< "postfix postfix/main_mailer_type string 'Internet Site'"
     apt-get install -y ghostscript imagemagick postgresql
     apt-get install -y sendmail-cf
     chmod a+rw /var/run/postgresql
+
+    echo "dash dash/sh boolean false" | debconf-set-selections
+    dpkg-reconfigure dash
 
     apt-get install -y gdm
     #dpkg-reconfigure gdm

--- a/vms/box_defs/ubuntu16/Vagrantfile
+++ b/vms/box_defs/ubuntu16/Vagrantfile
@@ -16,30 +16,34 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.provider "virtualbox" do |vb|
     #vb.gui = true
-    vb.memory = "2048"
-    vb.cpus = 2
+    vb.cpus = 3
+    vb.memory = "%d" % (1024 * 3)
   end
   config.vm.provision "shell", inline: <<-SHELL
     export DEBIAN_FRONTEND=noninteractive
+    set -e
     dpkg --add-architecture i386
     apt-get -qq update
     apt-get -qq -y dist-upgrade
 
     # these are needed to build
-    apt-get install -y git scons
-    apt-get install -y g++ gfortran
-    apt-get install -y lib32stdc++-5-dev libc6-dev-i386 libglu1-mesa-dev
+    apt-get install -y git scons g++ gfortran \
+            lib32stdc++-5-dev libc6-dev-i386 libglu1-mesa-dev \
+            libgsl-dev libtiff5-dev
     apt-get install -y libmotif-dev:i386 libx11-dev:i386 libxt-dev:i386
 
     # these are needed to install
-    apt-get install -y csh expect bc
-    apt-get install -y openjdk-8-jre
-    apt-get install -y rsh-server tftpd mutt sharutils gnome-power-manager k3b kdiff3 rarpd
+    #apt-get install -y openjdk-8-jre
+    apt-get install -y csh expect bc rsh-server tftpd mutt sharutils \
+            gnome-power-manager k3b kdiff3 rarpd
     #debconf-set-selections <<< "postfix postfix/mailname string your.hostname.com"
     #debconf-set-selections <<< "postfix postfix/main_mailer_type string 'Internet Site'"
-    apt-get install -y ghostscript imagemagick postgresql
-    apt-get install -y sendmail-cf
+    apt-get install -y ghostscript imagemagick postgresql sendmail-cf
+
     chmod a+rw /var/run/postgresql
+
+    echo "dash dash/sh boolean false" | debconf-set-selections
+    dpkg-reconfigure dash
 
     apt-get install -y gdm
     #dpkg-reconfigure gdm

--- a/vms/centos6/Vagrantfile
+++ b/vms/centos6/Vagrantfile
@@ -14,6 +14,9 @@
 def gui_enabled?
   !ENV.fetch('VMGUI', '').empty?
 end
+def ncpu
+  Integer(ENV.fetch('VMNCPU', '1'))
+end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "OpenVnmrJ/centos6"

--- a/vms/centos7/Vagrantfile
+++ b/vms/centos7/Vagrantfile
@@ -14,6 +14,9 @@
 def gui_enabled?
   !ENV.fetch('VMGUI', '').empty?
 end
+def ncpu
+  Integer(ENV.fetch('VMNCPU', '1'))
+end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "OpenVnmrJ/centos7"
@@ -23,9 +26,10 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |vb|
     # Display the VirtualBox GUI when booting the machine
     #vb.gui = true
+    vb.gui = gui_enabled?
     vb.linked_clone = true
-    vb.memory = "4096"
-    vb.cpus = 2
+    vb.memory = "%d" % (ncpu * 1024)
+    vb.cpus = ncpu
   end
   config.vm.provision "shell", inline: <<-SHELL
     echo "do nothing"

--- a/vms/macos10.10/Vagrantfile
+++ b/vms/macos10.10/Vagrantfile
@@ -16,9 +16,11 @@ def gui_enabled?
 end
 
 Vagrant.configure("2") do |config|
+  #config.vm.box = "AndrewDryga/vagrant-box-osx"
+
   config.vm.box = "OpenVnmrJ/macos10.10"
-  # only update vbguest on the box_defs/ boxes
-  config.vbguest.auto_update = false
+  #config.vbguest.auto_update = false
+
   config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.provider "virtualbox" do |vb|
     # Display the VirtualBox GUI when booting the machine
@@ -27,8 +29,31 @@ Vagrant.configure("2") do |config|
     vb.linked_clone = true
     # Customize the amount of memory on the VM:
     #vb.memory = "4096"
+
+    unless File.exist?('tmp2.vmdk')
+      vb.customize ['createhd', '--filename', 'tmp2.vmdk', '--size', 20*1024, '--format', 'vmdk' ]
+    end
+
+    vb.customize ['storageattach', :id,
+                  '--storagectl', 'SATA',
+                  '--port', 4,
+                  '--device', 0,
+                  '--type', 'hdd',
+                  '--medium', 'tmp2.vmdk']
+
   end
+
+  # create a case-sensitive filesystem on the vmdk from above
   config.vm.provision "shell", inline: <<-SHELL
-    echo "do nothing"
+    set -e
+    diskutil eraseDisk jhfsx Vagrant1 /dev/disk1
   SHELL
+
+  # brew runs as a user
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    set -e
+    brew update
+    brew install scons postgres
+  SHELL
+
 end

--- a/vms/ubuntu14/Vagrantfile
+++ b/vms/ubuntu14/Vagrantfile
@@ -14,6 +14,9 @@
 def gui_enabled?
   !ENV.fetch('VMGUI', '').empty?
 end
+def ncpu
+  Integer(ENV.fetch('VMNCPU', '1'))
+end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "OpenVnmrJ/ubuntu14"
@@ -23,10 +26,13 @@ Vagrant.configure("2") do |config|
     # Display the VirtualBox GUI when booting the machine
     vb.gui = gui_enabled?
     vb.linked_clone = true
-    #vb.memory = "4096"
-    #vb.cpus = 2
+    vb.memory = "%d" % (ncpu * 1024)
+    vb.cpus = ncpu
   end
   config.vm.provision "shell", inline: <<-SHELL
+    set -e
+    echo "dash dash/sh boolean false" | debconf-set-selections
+    DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
     echo "127.0.0.1 $(hostname)" >> /etc/hosts
     echo "do nothing"
   SHELL

--- a/vms/ubuntu16/Vagrantfile
+++ b/vms/ubuntu16/Vagrantfile
@@ -14,6 +14,9 @@
 def gui_enabled?
   !ENV.fetch('VMGUI', '').empty?
 end
+def ncpu
+  Integer(ENV.fetch('VMNCPU', '1'))
+end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "OpenVnmrJ/ubuntu16"
@@ -23,10 +26,11 @@ Vagrant.configure("2") do |config|
     # Display the VirtualBox GUI when booting the machine
     vb.gui = gui_enabled?
     vb.linked_clone = true
-    #vb.memory = "4096"
-    #vb.cpus = 2
+    vb.memory = "%d" % (ncpu * 1024)
+    vb.cpus = ncpu
   end
   config.vm.provision "shell", inline: <<-SHELL
+    set -e
     echo "do nothing"
   SHELL
 end

--- a/vms/ubuntu18/Vagrantfile
+++ b/vms/ubuntu18/Vagrantfile
@@ -1,12 +1,13 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 #
-# Copyright (C) 2016  Michael Tesch
+# Copyright (C) 2018  Michael Tesch
 #
-# You may distribute under the terms of either the GNU General Public
-# License or the Apache License, as specified in the LICENSE file.
+# This file is a part of the OpenVnmrJ project.  You may distribute it
+# under the terms of either the GNU General Public License or the
+# Apache 2.0 License, as specified in the LICENSE file.
 #
-# For more information, see the LICENSE file.
+# For more information, see the OpenVnmrJ LICENSE file.
 #
 
 # Returns true if `VMGUI` environment variable is set to a non-empty
@@ -14,40 +15,48 @@
 def gui_enabled?
   !ENV.fetch('VMGUI', '').empty?
 end
+def ncpu
+  Integer(ENV.fetch('VMNCPU', '1'))
+end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "bento/ubuntu-18.04"
   config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.provider "virtualbox" do |vb|
-    #vb.gui = true
-    vb.memory = "2048"
-    vb.cpus = 2
+    vb.cpus = ncpu
+    vb.memory = "%d" % (ncpu * 1024)
     # Display the VirtualBox GUI when booting the machine?
     vb.gui = gui_enabled?
   end
   config.vm.provision "shell", inline: <<-SHELL
     export DEBIAN_FRONTEND=noninteractive
+    set -e
     dpkg --add-architecture i386
-    apt -qq update
-    apt -qq -y dist-upgrade
+    apt-get -qq update
+    apt-get -qq -y dist-upgrade
 
     # these are needed to build
-    apt install -y git scons
-    apt install -y g++ gfortran
-    apt install -y lib32stdc++-7-dev libc6-dev-i386 libglu1-mesa-dev
-    apt install -y libmotif-dev:i386 libx11-dev:i386 libxt-dev:i386
+    apt-get install -y git scons g++ gfortran gdm3 gnome-session \
+      lib32stdc++-7-dev libc6-dev-i386 libglu1-mesa-dev
 
     # these are needed to install
-    apt install -y csh expect bc
-    apt install -y openjdk-8-jre
-    apt install -y rsh-server tftpd mutt sharutils gnome-power-manager k3b kdiff3 rarpd
+    #apt-get install -y openjdk-8-jre
+    apt-get install -y csh expect bc rsh-server tftpd \
+      mutt sharutils gnome-power-manager k3b kdiff3 rarpd \
+      ghostscript imagemagick postgresql sendmail-cf \
+      gedit dos2unix zip cups gnuplot gnome-terminal enscript
     #debconf-set-selections <<< "postfix postfix/mailname string your.hostname.com"
     #debconf-set-selections <<< "postfix postfix/main_mailer_type string 'Internet Site'"
-    apt install -y ghostscript imagemagick postgresql
-    apt install -y sendmail-cf
     chmod a+rw /var/run/postgresql
 
-    apt install -y gnome-session gdm3
+    # these are needed to build
+    # apt-get uninstalls these if an amd64 version is installed for something else >:(
+    # so install them last...
+    apt-get install -y libmotif-dev:i386 libx11-dev:i386 libxt-dev:i386 libxft-dev:i386
+
+    echo "dash dash/sh boolean false" | debconf-set-selections
+    dpkg-reconfigure dash
+
     # dpkg-reconfigure gdm
     # echo "127.0.0.1 $(hostname)" >> /etc/hosts
   SHELL


### PR DESCRIPTION
- added script install_test.sh for gui-less install
- updates to install/test within VM functionality
- move install_test.sh to OpenVnmrJ repo.
- fixes for vm vjqa
- add an option to pass flags to install_test.sh (ie -F '-c inova')
- treat fedora like centos
- added some missing rpm packages for centos7
- moved logging stuff to loglib.sh shell-function library
- default log file name is now build_vm...log
- take ubuntu18 and macos10.10 out of 'all' target until they work
- catch a bunch of error conditions
- retrieve VJQA test result as log file named vjqa_....txt
- make sure vagrant setup scripts fail on error with set -e
- default the debian installations to use bash as /bin/sh (not dash!)
- started (an unfinished) 'package' option to build .rpm/.deb
- log runtimes of various build stages
- checkout less git depth for shallow builds
- use 4 cpus on VMs instead of 2 for faster build.
- make Vagrantfile installs fail if packages dont install