### PR TITLE
update the vm_build.sh script and add some Vagrantfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# emacs temp files
+*~
+
+# logfiles
+logs/*.txt
+logs/*.log
+
+# vagrant runtime files
+.vagrant/
+vagrant.ssh.config

--- a/README.md
+++ b/README.md
@@ -70,30 +70,33 @@ There are several ready-to-use VM descriptions (using
 OS in a VM for building and running OpenVnmrJ.  The Vagrant files and
 machines live in the [vms/](vms/) directory.
 
-To build OpenVnmrJ using one of these machine descriptions, after
-installing Vagrant and the [vbguest
-plugin](https://github.com/dotless-de/vagrant-vbguest), just checkout
-this ovjTools repository and then run the VM build script
+To build OpenVnmrJ using one of these machine descriptions, install
+[Vagrant](https://www.vagrantup.com/) and the [vbguest
+plugin](https://github.com/dotless-de/vagrant-vbguest), then from this
+repository (`ovjTools`) run the VM build script
 [build_vm.sh](bin/build_vm.sh):
 
 (in this example CentOS 6)
 
 ```sh
 git clone git@github.com:OpenVnmrJ/ovjTools.git
-export OVJ_TOOLS=`pwd`/ovjTools
-${OVJ_TOOLS}/bin/build_vm.sh centos6   # do the actual build, will take ~1 h the first time
-...
-cd ${OVJ_TOOLS}/vms/centos6
-VMGUI=y vagrant reload                 # this will reboot the VM in graphical mode
+cd ovjTools
+./bin/build_vm.sh centos6   # do the actual build, may take ~1 h the first time
 ```
 
 to build for multiple OS targets at the same time, just add the target
 name to the command line, currently tested targets are `centos6`,
-`centos7`, `ubuntu14`, `ubuntu16`, and `ubuntu18`.
+`centos7`, `ubuntu14`, `ubuntu16`, and `ubuntu18`.  By default, the
+build_vm.sh script performs a full "from scratch" clean + build +
+install + test cycle, but it can be limited to do any one or
+combination of these by simply specifying the action on the command
+line, a basic: `./build_vm.sh build centos6` would just build
+OpenVnmrJ on an existing centos6 without cleaning it, and without
+installing or testing it.
 
-The [build_vm.sh](bin/build_vm.sh) script lets you specify the git
-branch and github username.  To build the "development" branch from a
-github user "ghuser" on both centos6 and ubuntu14 :
+The [build_vm.sh](bin/build_vm.sh) script can specify the git branch
+and github username.  To build the "development" branch from a github
+user "ghuser" on both centos6 and ubuntu14 :
 
 ```sh
 ./bin/build_vm.sh centos6 ubuntu14 --gitname ghuser --branch development 
@@ -103,12 +106,12 @@ If there are any build errors, you can log into the VM locally through
 ssh and inspect the build.log:
 
 ```sh
-cd ${OVJ_TOOLS}/vms/centos6
-vagrant up
-vagrant ssh
-[now logged into the VM...]
-cd $ovjBuildDir/logs/
-more build*
+ovjTools $ cd ./vms/centos6
+centos6 $ vagrant up
+centos6 $ vagrant ssh
+[now logged into a shell on the VM...]
+vagrant $ cd $ovjBuildDir/logs/
+vagrant $ more build*
 ```
 
 The actual install of OpenVnmrJ (currently) requires graphical user

--- a/bin/build_vm.sh
+++ b/bin/build_vm.sh
@@ -389,7 +389,11 @@ setup_target() {
     cmdspin vagrant up ${OVJ_VM_UPFLAGS} || return $?
     vagrant ssh-config > ./vagrant.ssh.config || return $?
 
-    # setup environment in the VM
+    # boop the VM to make sure it's up and running
+    sleep 1
+    vrun 'echo hello world' || true
+
+    # setup shell environment vars in the VM
     case "${TARGET_OS}" in
         centos*|fedora*)
             vrun 'echo "export ovjBuildDir=$HOME/ovjbuild" >> ~/.bashrc'

--- a/bin/build_vm.sh
+++ b/bin/build_vm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2016  Michael Tesch
 #
@@ -14,7 +14,7 @@
 #
 
 CMDLINE="$0 $*"
-SCRIPT=$(basename "$0")
+SCRIPT="$(basename "$0")"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ERRCOUNT=0
 onerror() {
@@ -28,19 +28,25 @@ onerror() {
 trap onerror ERR
 
 DATESTRING="$(date +"%Y%m%d_%H%M%S")"
-TARGETS=
-ACTIONS=
+CORES="$(grep -c ^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu || echo "$NUMBER_OF_PROCESSORS")"
+SUMMARY=
+: "${TARGETS=}"
+: "${ACTIONS=}"
 : "${OVJ_FRESHSRC=no}"
 : "${OVJ_GITBRANCH=master}"
 : "${OVJT_GITBRANCH=master}"
 : "${OVJ_DEVELOPER=OpenVnmrJ}"
-: "${OVJ_VMNCPU=3}"
+: "${OVJ_VM_GUI=}"
+: "${OVJ_VM_NCPU=$(( CORES / 2 ))}"
+: "${OVJ_VM_MEM=$(( OVJ_VM_NCPU * 1024 ))}"
+: "${OVJ_VM_UPFLAGS=}"
 : "${VERBOSE=3}"
 : "${OVJ_LOGFILE=build_vm-${DATESTRING}.log}"
 : "${OVJ_KEEPRUN=no}"
 : "${OVJ_KEEPBOX=no}"
 : "${OVJ_BR_FLAGS="--srcreset"}"
 : "${OVJ_TI_FLAGS="-f -v"}"
+: "${OVJ_NMRADMIN=vnmr1}"
 
 # set OVJ_TOOLS if necessary
 if [ "x${OVJ_TOOLS}" = "x" ] ; then
@@ -65,34 +71,43 @@ usage:
   $SCRIPT <targets...> [action] [options...]
 
 targets:
-  <centos6|centos7|macos10.10|ubuntu14|ubuntu16|...>
+  <all|centos6|centos7|macos10.10|ubuntu14|ubuntu16|...>
+  all = "centos6 centos7 ubuntu14 ubuntu16"
 
 actions:
   build                  - build OpenVnmrJ on the specified platform,
                            building any necessary VM images on the way (default).
-  package                - make OpenVnmrJ packages (rpm/deb) for the OS
   install                - install OpenVnmrJ on the target VM
   test                   - test OpenVnmrJ on the target VM using vjqa
   uninstall              - uninstall OpenVnmrJ on the target VM
   clean                  - destroy all VMs used for given platform
   distclean              - destroy all VMs and all box templates
+  setupvm                - just setup VM and possibly VM "box" (included in 
+                           other actions automatically)
+  package (unfinished)   - make OpenVnmrJ packages (rpm/deb) for the target OS
 
 options:
-  -f|--freshsrc          - remove build dir, clone fresh repos [${OVJ_FRESHSRC}]
-  -k|--keeprunning       - leave the VM running after building [${OVJ_KEEPRUN}]
-  --keepbox              - save the VM 'box' after building it [${OVJ_KEEPBOX}]
-  -b|--branch branch     - branch to build [${OVJ_GITBRANCH}]
-  -u|--gitname developer - github account name to build [${OVJ_DEVELOPER}]
-  --tbranch branch_name  - branch to clone for ovjTools [${OVJT_GITBRANCH}]
-  -B|--brflags           - flags to pass to build_release.sh [${OVJ_BR_FLAGS}]
-  -F|--tiflags           - flags to pass to test_install.sh [${OVJ_TI_FLAGS}]
-  -N|--ncpu              - how many cpus to give to each VM [${OVJ_VMNCPU}]
-  -v|--verbose           - be more verbose (can add multiple times)
-  -q|--quiet             - be more quiet   (can add multiple times)
-  -h|--help              - print this message and exit
+  -f|--freshsrc           - remove build dir, clone fresh repos [${OVJ_FRESHSRC}]
+  -k|--keeprunning        - leave the VM running after actions are done [${OVJ_KEEPRUN}]
+  --keepbox               - save the VM 'box' after building it [${OVJ_KEEPBOX}]
+  -b|--branch <branch>    - branch to build [${OVJ_GITBRANCH}]
+  -u|--gitname <ghlogin>  - github account name to build [${OVJ_DEVELOPER}]
+  --tbranch <branch_name> - branch to clone for ovjTools [${OVJT_GITBRANCH}]
+  -B|--brflags <flags>    - flags to pass to build_release.sh [${OVJ_BR_FLAGS}]
+  -F|--tiflags <flags>    - flags to pass to test_install.sh [${OVJ_TI_FLAGS}]
+  -G|--vmgui              - boot the VM with a graphical interface (not headless) [${OVJ_VM_GUI}]
+  -N|--ncpu <N>           - how many cpus to give to each VM [${OVJ_VM_NCPU}]
+  -M|--vmmem <N>          - how much memory (MB) to give to each VM [${OVJ_VM_MEM}]
+  -p|--vmprov             - re-run the VM provision (vagrant up --provision) [${OVJ_VM_UPFLAGS}]
+  -v|--verbose            - be more verbose (can add multiple times)
+  -q|--quiet              - be more quiet   (can add multiple times)
+  -h|--help               - print this message and exit
 
 Environment Variables:
-OVJ_TOOLS     -> path to ovjTools, VM will be in \$OVJ_TOOLS/vms/<os>/
+OVJ_TOOLS     -> path to ovjTools [${OVJ_TOOLS}]
+                 VM will be in \$OVJ_TOOLS/vms/<os>/
+VAGRANT_HOME  -> tells vagrant where to keep VM files
+
 EOF
 }
 
@@ -117,14 +132,17 @@ while [ $# -gt 0 ]; do
         --tbranch)              OVJT_GITBRANCH="$2"; shift    ;;
         -B|--brflags)           OVJ_BR_FLAGS="$2"; shift      ;;
         -F|--tiflags)           OVJ_TI_FLAGS="$2"; shift      ;;
-        -N|--ncpu)              OVJ_VMNCPU="$2"; shift      ;;
+        -p|--vmprov)            OVJ_VM_UPFLAGS="${OVJ_VM_UPFLAGS} --provision" ;;
+        -G|--vmgui)             OVJ_VM_GUI=yes                ;;
+        -M|--vmmem)             OVJ_VM_MEM="$2"; shift        ;;
+        -N|--ncpu)              OVJ_VM_NCPU="$2"; shift       ;;
         -h|--help)              usage                         ;;
         -v|--verbose)           VERBOSE=$(( VERBOSE + 1 )) ;;
         -q|--quiet)             VERBOSE=$(( VERBOSE - 1 )) ;;
         all)
             TARGETS="centos6 centos7 ubuntu14 ubuntu16 "
             ;;
-        build|package|install|test|uninstall|clean|distclean)
+        setupvm|build|package|install|test|uninstall|clean|distclean)
             ACTIONS="${ACTIONS} $key"
             ;;
         *)
@@ -179,13 +197,14 @@ vrun () {
     trap "kill $SPINNER_PID" EXIT
     # run command in VM
     vagrant ssh -c "$VCMD"
+    #vagrant ssh -c "bash -lc '$VCMD'"
     retval=$?
     # Kill the spinner loop and unset the EXIT trap
     kill -PIPE $SPINNER_PID
     if [ -t 3 ]; then printf '\b.' >&3 ; fi
     trap " " EXIT
     local dur
-    dur=$(TZ=UTC0 printf '%(%H:%M:%S)T\n' "$(( SECONDS - start ))")
+    dur=$(printsec "$(( SECONDS - start ))")
     if [ $retval = 0 ]; then
         echo "${magenta}OK $dur${normal}"
         if [ $VERBOSE -le 3 ] && [ -t 3 ]; then
@@ -216,8 +235,8 @@ distclean_target() {
 
     log_info "distcleaning vms/box_defs/${TARGET_OS}"
     if ! cd "${OVJ_TOOLS}/vms/box_defs/${TARGET_OS}" ; then
-        log_warn "target box def for '${TARGET_OS}' missing"
-        return 1
+        log_warn "No box def for target '${TARGET_OS}', can't distclean it."
+        return 0
     fi
     log_cmd rm -f package.box
     vagrant destroy -f
@@ -284,9 +303,9 @@ build_box() {
     if [[ "${TARGET_OS}" == macos* ]]; then
         JAVA_DMG=(jdk-8u*-macosx-x64.dmg)
         if [ ! -f "${JAVA_DMG}" ]; then
-            log_error "Please download the macOS java SDK (${JAVA_DMG}) and place it in $(pwd) before running this."
+            log_error "Please download the macOS java SDK (${JAVA_DMG}) and place it in '$(pwd)' and try again."
             log_error " maybe from http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html"
-            exit -1
+            exit 1
         fi
     fi
 
@@ -301,6 +320,7 @@ build_box() {
 
     # build and setup the VM
     log_info "Creating the box VM '$BOXNAME'"
+    export OVJ_VM_NCPU OVJ_VM_MEM OVJ_VM_GUI
     cmdspin vagrant up || return $?
     vagrant ssh-config > ./vagrant.ssh.config || return $?
 
@@ -365,7 +385,8 @@ setup_target() {
         cmdspin vagrant halt
     fi
     log_info "Spinning up build VM in $(pwd)"
-    VMNCPU=${OVJ_VMNCPU} cmdspin vagrant up || return $?
+    export OVJ_VM_NCPU OVJ_VM_MEM OVJ_VM_GUI
+    cmdspin vagrant up ${OVJ_VM_UPFLAGS} || return $?
     vagrant ssh-config > ./vagrant.ssh.config || return $?
 
     # setup environment in the VM
@@ -373,24 +394,37 @@ setup_target() {
         centos*|fedora*)
             vrun 'echo "export ovjBuildDir=$HOME/ovjbuild" >> ~/.bashrc'
             vrun 'echo "export OVJ_TOOLS=$ovjBuildDir/ovjTools" >> ~/.bashrc'
+            vrun 'echo "export OVJ_NMRADMIN=vnmr1" >> ~/.bashrc'
             ;;
-        ubuntu*)
+        ubuntu*|mint*)
             vrun 'echo "export ovjBuildDir=$HOME/ovjbuild" >> ~/.profile'
             vrun 'echo "export OVJ_TOOLS=$ovjBuildDir/ovjTools" >> ~/.profile'
+            vrun 'echo "export OVJ_NMRADMIN=vnmr1" >> ~/.profile'
             ;;
         macos*)
             # case-sensitive filesystem at /Volumes/Vagrant1/
             vrun 'echo "export ovjBuildDir=/Volumes/Vagrant1/ovjbuild" >> ~/.profile'
             vrun 'echo "export OVJ_TOOLS=$ovjBuildDir/ovjTools" >> ~/.profile'
+            vrun 'echo "export OVJ_NMRADMIN=$(whoami)" >> ~/.profile'
+            OVJ_NMRADMIN=$(vagrant ssh -c whoami)
+            log_info "MacOS, set OVJ_NMRADMIN=$OVJ_NMRADMIN"
             #scp -F vagrant.ssh.config "Test Developer.cer" default:
-            #vrun "sudo security -v add-trusted-cert -d -r trustRoot -p codeSign -k /Library/Keychains/System.keychain 'Test Developer.cer'"
+            #vrun "sudo security -v add-trusted-cert -d -r trustRoot \
+            #  -p codeSign -k /Library/Keychains/System.keychain 'Test Developer.cer'"
             #vrun "security find-identity -p codesigning"
             ;;
         *)
-            log_error "Unknown target os '${TARGET_OS}'"
+            log_warn "Unknown target os '${TARGET_OS}', spamming rc files:"
+            vrun 'echo "export ovjBuildDir=$HOME/ovjbuild" >> ~/.bashrc'
+            vrun 'echo "export OVJ_TOOLS=$ovjBuildDir/ovjTools" >> ~/.bashrc'
+            vrun 'echo "export OVJ_NMRADMIN=vnmr1" >> ~/.bashrc'
+            vrun 'echo "export ovjBuildDir=$HOME/ovjbuild" >> ~/.profile'
+            vrun 'echo "export OVJ_TOOLS=$ovjBuildDir/ovjTools" >> ~/.profile'
+            vrun 'echo "export OVJ_NMRADMIN=vnmr1" >> ~/.profile'
+            vrun 'sudo chsh -s $(which bash) $(whoami)'
     esac
 
-    # check if setting OVJ_TOOLS in the environment works
+    # check that setting OVJ_TOOLS in the environment works
     vrun 'echo ovjBuildDir=$ovjBuildDir'
     vrun 'echo OVJ_TOOLS=$OVJ_TOOLS'
     vrun 'scons -v'
@@ -427,34 +461,40 @@ build_target() {
     fi
 
     # make the build dir
-    #vrun 'if [ -d ${ovjBuildDir} ]; then echo "removing build dir"; rm -rf ${ovjBuildDir} ; fi '
     vrun 'mkdir -p ${ovjBuildDir}' || return $?
 
     # checkout the sources within the VM
+
+    # update OpenVnmrJ sourece from origin
     if ! vrun "cd \$ovjBuildDir/OpenVnmrJ"; then
         log_info "checking out OpenVnmrJ 'http://github.com/${OVJ_DEVELOPER}/OpenVnmrJ.git' b=${OVJ_GITBRANCH}"
-        vrun "cd \$ovjBuildDir && pwd"
-        vrun "cd \$ovjBuildDir && git clone --depth 1 --branch ${OVJ_GITBRANCH} http://github.com/${OVJ_DEVELOPER}/OpenVnmrJ.git"
+        vrun "cd \$ovjBuildDir && pwd" || return $?
+        vrun "cd \$ovjBuildDir && git clone --depth 3 --branch ${OVJ_GITBRANCH} http://github.com/${OVJ_DEVELOPER}/OpenVnmrJ.git" || return $?
     else
         # make sure that 'origin' points at right git remote
-        vrun "cd \$ovjBuildDir/OpenVnmrJ && git remote set-url origin http://github.com/${OVJ_DEVELOPER}/OpenVnmrJ.git"
-        vrun "cd \$ovjBuildDir/OpenVnmrJ && git fetch --depth 1 origin ${OVJ_GITBRANCH}:${OVJ_GITBRANCH}"
+        vrun "cd \$ovjBuildDir/OpenVnmrJ && git remote set-url origin http://github.com/${OVJ_DEVELOPER}/OpenVnmrJ.git" || return $?
+        vrun "cd \$ovjBuildDir/OpenVnmrJ && git fetch --depth 3 origin" || return $?
+        vrun "cd \$ovjBuildDir/OpenVnmrJ && git pull origin ${OVJ_GITBRANCH}" || return $?
     fi
+
+    # update ovjTools from origin
     if ! vrun "cd \$ovjBuildDir/ovjTools"; then
         log_info "checking out ovjTools 'http://github.com/${OVJ_DEVELOPER}/ovjTools.git' b=${OVJT_GITBRANCH}"
-        vrun "cd \$ovjBuildDir && git clone --depth 1 --branch ${OVJT_GITBRANCH} http://github.com/${OVJ_DEVELOPER}/ovjTools.git"
+        vrun "cd \$ovjBuildDir && git clone --depth 3 --branch ${OVJT_GITBRANCH} http://github.com/${OVJ_DEVELOPER}/ovjTools.git" || return $?
         # this might be unnecessary?
         #vrun 'cd ${ovjBuildDir} &&cp -r ovjTools/bin . '
     else
         # make sure that 'origin' points at right git remote
-        vrun "cd \$ovjBuildDir/ovjTools && git remote set-url origin http://github.com/${OVJ_DEVELOPER}/ovjTools.git"
-        vrun "cd \$ovjBuildDir/ovjTools && git fetch --depth 1 origin ${OVJT_GITBRANCH}:${OVJT_GITBRANCH}"
+        vrun "cd \$ovjBuildDir/ovjTools && git remote set-url origin http://github.com/${OVJ_DEVELOPER}/ovjTools.git" || return $?
+        # get the latest 
+        vrun "cd \$ovjBuildDir/ovjTools && git fetch --depth 3 origin" || return $?
+        vrun "cd \$ovjBuildDir/ovjTools && git pull origin ${OVJT_GITBRANCH}" || return $?
     fi
 
     # verify that the checkout worked
     vrun 'ls $OVJ_TOOLS' || return $?
-    vrun "cd \$ovjBuildDir/OpenVnmrJ && git branch"
-    vrun "cd \$ovjBuildDir/OpenVnmrJ && git checkout "
+    vrun "cd \$ovjBuildDir/OpenVnmrJ && git branch" || return $?
+    vrun "cd \$ovjBuildDir/OpenVnmrJ && git checkout " || return $?
 
     #
     # build & package OpenVnmrJ!
@@ -470,18 +510,18 @@ build_target() {
 
     retval=$?
     if [ $retval = 0 ]; then
-        # capture a list of what was built in our LOGFILE
         log_info "RET: $retval"
     else
         retval=$?
         log_warn "RET: $retval"
     fi
 
+    # capture a list of what was built in our LOGFILE
     vrun '${ovjBuildDir}/ovjTools/bin/whatsin $(ls -t ${ovjBuildDir}/logs/build* | head -1) | tail -60'
     vrun 'ls -l ${ovjBuildDir}/dvd*'
 
     case "${TARGET_OS}" in
-        centos*|fedora*)
+        centos*|fedora*|freebsd*)
             # the install script su's to vnmr1, so these need to be
             # read/exec by vnmr1
             vrun 'chmod a+xr ${ovjBuildDir}/..'
@@ -489,13 +529,6 @@ build_target() {
             vrun 'chmod a+xr ${ovjBuildDir}/dvdimageOVJ*' || return $?
             ;;
     esac
-
-    # build done, shutdown the VM, print status
-    if [ $retval = 0 ]; then
-        log_msg "Build '${TARGET_OS}' success."
-    else
-        log_error "Build '${TARGET_OS}' failed.  Vagrant VM at ${OVJ_TOOLS}/vms/${TARGET_OS}"
-    fi
 
     return $retval
 }
@@ -528,7 +561,7 @@ package_target() {
         centos*|fedora*)
             package_rpm "$TARGET_OS" || return $?
             ;;
-        ubuntu*|debian*)
+        ubuntu*|debian*|mint*)
             log_error "Debian .deb packaging unfinished"
             #package_deb "$TARGET_OS" || return $?
             ;;
@@ -554,32 +587,41 @@ install_target() {
         vrun 'mv install_test.sh $ovjBuildDir/OpenVnmrJ/scripts/' || return $?
     fi
 
-    # get rid of any existing vjqa logs
-    if [ "$COMMAND" = test ]; then
-        vrun 'sudo rm -f ~vnmr1/vnmrsys/ovj_qa/ovjtest/reports/20*'
-    fi
-
     # run the remote part
-    time vrun "cd \"\${OVJ_TOOLS}\" && sudo \$ovjBuildDir/OpenVnmrJ/scripts/install_test.sh ${OVJ_TI_FLAGS} $COMMAND"
+    time vrun "cd \"\${OVJ_TOOLS}\" && sudo OVJ_NMRADMIN=${OVJ_NMRADMIN} \$ovjBuildDir/OpenVnmrJ/scripts/install_test.sh ${OVJ_TI_FLAGS} $COMMAND"
     retval=$?
 
     if [ "$COMMAND" = test ]; then
         # if testing, copy test results back to OVJ_TOOLS dir
         local retval2
+        local vjqa_file="${OVJ_TOOLS}/logs/vjqa-${TARGET_OS}-${DATESTRING}.txt"
+        local gold_vjqa_file="${OVJ_TOOLS}/logs/gold_vjqa/vjqa-${TARGET_OS}.txt"
         log_cmd scp -F vagrant.ssh.config \
-                default:~vnmr1/vnmrsys/ovj_qa/ovjtest/reports/report.txt \
-                "${OVJ_TOOLS}/vjqa-${TARGET_OS}-${DATESTRING}.txt"
+                default:~"$OVJ_NMRADMIN"/vnmrsys/ovj_qa/ovjtest/reports/report.txt \
+                "$vjqa_file"
         retval2=$?
         if [ $retval2 -ne 0 ]; then
             log_error "Unable to fetch VJQA test result 'report.txt' from VM"
+            # make sure to return fail value
+            retval=1
+        else
+            # compare the vjqa log with "gold" version for this OS
+            # first 9 lines of the files have date strings, so ignore those
+            if ! cmp <(tail +9 "$gold_vjqa_file") <(tail +9 "$vjqa_file") > /dev/null 2>&1 ; then
+                if [ -f "$gold_vjqa_file" ]; then
+                    local DIFF_COUNT
+                    DIFF_COUNT=$(diff "${gold_vjqa_file}" "${vjqa_file}" | wc -l)
+                    log_warn "vjqa results differ from the 'gold' for '${TARGET_OS}' on $DIFF_COUNT lines..."
+                    log_warn "  diff ${gold_vjqa_file} ${vjqa_file}"
+                    SUMMARY=$(printf "%s\n%s" "${SUMMARY}" "${cyan} diff ${gold_vjqa_file} ${vjqa_file}${normal}")
+                    log_cmd "diff ${gold_vjqa_file} ${vjqa_file} | head"
+                else
+                    log_warn "no GOLD standard file for vjqa on '${TARGET_OS}', saving ours :)"
+                    log_cmd "cp ${vjqa_file} ${gold_vjqa_file}"
+                    #retval=1
+                fi
+            fi
         fi
-    fi
-
-    # test done, shutdown the VM, print status
-    if [ $retval = 0 ]; then
-        log_msg "'$COMMAND' '${TARGET_OS}' success."
-    else
-        log_error "'$COMMAND' '${TARGET_OS}' failed.  Vagrant VM at ${OVJ_TOOLS}/vms/${TARGET_OS}"
     fi
 
     return $retval
@@ -601,21 +643,36 @@ if [ "x${TARGETS}" = x ]; then
     usage
 fi
 
+# make sure we can run vagrant
+if ! [ -x "$(command -v vagrant)" ]; then
+    log_error "Error: vagrant is not installed."
+    exit 1
+fi
+log_cmd vagrant version
+
+# default actions
+if [ -z "$ACTIONS" ]; then
+    ACTIONS="clean build install test"
+    log_info "No actions specified, performing default: $ACTIONS"
+fi
+
 # do the action on all the targets
 for TARGET in $TARGETS ; do
     # setup the logfile
-    log_setup "build_vm-${TARGET}-${DATESTRING}.log" "${OVJ_TOOLS}"
+    log_setup "build_vm-${TARGET}-${DATESTRING}.log" "${OVJ_TOOLS}/logs"
     log_info "Target:  $TARGET"
     log_info "Actions: $ACTIONS"
 
     ISUP=no
     for ACTION in $ACTIONS ; do
+        action_start=$SECONDS
         if [ $ISUP = no ]; then
             case ${ACTION} in
-                build|package|install|test|uninstall)
+                setupvm|build|package|install|test|uninstall)
                     log_info " -----------------------------------------"
                     log_warn "     Setup '${TARGET}'"
                     if ! setup_target "$TARGET" ; then
+                        SUMMARY=$(printf "%s\n%s" "${SUMMARY}" "${red}$ACTION '${TARGET}' failed.${normal} ($duration): $LOGFILE")
                         log_error "Unable to start '${TARGET}'"
                         break
                     fi
@@ -626,33 +683,51 @@ for TARGET in $TARGETS ; do
         log_info " -----------------------------------------"
         log_warn "     ACTION=${ACTION} TARGET=${TARGET}"
         log_info " -----------------------------------------"
+
+        retval=0
         case ${ACTION} in
+            setupvm)
+                ;;
             build)
                 validate_repo
-                if ! build_target "$TARGET" ; then log_error "$ACTION failed"; break ; fi
+                build_target "$TARGET" || retval=$?
                 ;;
             package)
-                if ! package_target "$TARGET" ; then log_error "$ACTION failed"; break ; fi
+                package_target "$TARGET" || retval=$?
                 ;;
             install)
-                if ! install_target "$TARGET" install ; then log_error "$ACTION failed"; break ; fi
+                install_target "$TARGET" install || retval=$?
                 ;;
             test)
-                if ! install_target "$TARGET" test; then log_error "$ACTION failed"; break ; fi
+                install_target "$TARGET" test || retval=$?
                 ;;
             uninstall)
-                if ! install_target "$TARGET" uninstall; then log_warn "$ACTION failed"; fi
+                install_target "$TARGET" uninstall || retval=$?
                 ;;
             clean)
-                if ! clean_target "$TARGET" ; then log_warn "clean '$TARGET' failed."; fi
+                clean_target "$TARGET" || retval=$?
                 ISUP=no
                 ;;
             distclean)
-                if ! clean_target "$TARGET" ; then log_warn "clean '$TARGET' failed."; fi
-                if ! distclean_target "$TARGET"; then log_warn "distclean '$TARGET' failed."; break; fi
+                if ! clean_target "$TARGET" ; then retval=$? ; log_warn "clean '$TARGET' failed."; fi
+                distclean_target "$TARGET" || retval=$?
                 ISUP=no
                 ;;
+            *)
+                log_info "Unrecognized action '${ACTION}', ignoring."
+                ;;
         esac
+        # action done
+        action_duration=$(( $SECONDS - $action_start ))
+        duration="$(printsec $action_duration)"
+
+        if [ $retval = 0 ]; then
+            log_msg "$ACTION '${TARGET}' success. ($duration)"
+            SUMMARY=$(printf "%s\n%s" "${SUMMARY}" "${white}$ACTION '${TARGET}' success. ($duration)${normal}")
+        else
+            log_error "$ACTION '${TARGET}' failed. ($duration) Vagrant VM at ${OVJ_TOOLS}/vms/${TARGET}"
+            SUMMARY=$(printf "%s\n%s" "${SUMMARY}" "${red}$ACTION '${TARGET}' failed.${normal} ($duration): $LOGFILE")
+        fi
     done
     if [ $ISUP = yes ]; then
         if ! shutdown_target "$TARGET" ; then log_error "Error shutting down VM '$TARGET'" ; fi
@@ -663,10 +738,13 @@ for TARGET in $TARGETS ; do
 done
 
 if [ "${ACTION}" = clean ] || [ "${ACTION}" = distclean ]; then
+    log_info "$SUMMARY"
     log_info "vagrant global-status after cleaning:"
     log_cmd vagrant global-status
     exit 0
 fi
 
-log_info "$SCRIPT done, ${ERRCOUNT} errors.  Logfile: $LOGFILE"
+log_info "${SUMMARY}"
+log_info "${SCRIPT} done, ${ERRCOUNT} errors.  Logfile: ${LOGFILE}"
+
 exit ${ERRCOUNT}

--- a/bin/loglib.sh
+++ b/bin/loglib.sh
@@ -95,11 +95,22 @@ log_msg   () { log_msg_ 1 "$*" ; }
 log_warn  () { log_msg_ 2 "$*" ; }
 log_info  () { log_msg_ 3 "$*" ; }
 log_debug () { log_msg_ 4 "$*" ; }
-log_cmd   () { log_info "\$ $*" ; "$@" ; }
+log_cmd   () { log_info "\$ $*" ; eval "$@" ; }
+
+# convert seconds to a readable HH:MM:SS string
+printsec () {
+    local SECS=$1
+    if date --date "@1" +%H:%M:%S >/dev/null 2>&1 ; then
+        # gnu date
+        date -u --date "@$SECS" +%H:%M:%S
+    else
+        # bsd date
+        date -u -r "$SECS" +%H:%M:%S
+    fi
+}
+
+# Run a command, spin a wheelie while it's running
 cmdspin () {
-    #
-    # Run a command, spin a wheelie while it's running
-    #
     local start=$SECONDS
     log_info "Cmd started $(date)"
     log_info "\$ $*"
@@ -122,7 +133,7 @@ cmdspin () {
     trap " " EXIT
     if [ -t 3 ]; then printf '\b.\n' >&3 ; fi
     local dur=$(( $SECONDS - $start ))
-    log_info "Cmd returned: $retval, duration: $(TZ=UTC0 printf '%(%H:%M:%S)T\n' "$dur")"
+    log_info "Cmd returned: $retval, duration: $(printsec "$dur")"
     return $retval
 }
 

--- a/logs/gold_vjqa/vjqa-centos6.txt
+++ b/logs/gold_vjqa/vjqa-centos6.txt
@@ -1,0 +1,392 @@
+ 
+ 
+Start QA testing
+Mar 27 2019 at 20:52:05
+ 
+
+OpenVnmrJ VERSION 1.1 REVISION A
+March 27, 2019
+propulse
+
+OS:
+CentOS release 6.10 (Final)
+ 
+Installation tests
+   Test       : VnmrJ installation
+     ***Failed: VnmrJ installation
+ 
+Macro syntax tests
+   Test       : Macro syntax of /vnmr/autotest/maclib/
+        Passed: 309 macros
+   Test       : Macro syntax of /vnmr/biopack/BioPack.dir/BP_files/maclib/
+   Test       : Macro syntax of /vnmr/biopack/maclib/
+        Passed: 1052 macros
+   Test       : Macro syntax of /vnmr/biosolidspack/maclib/
+        Passed: 240 macros
+   Test       : Macro syntax of /vnmr/craft/maclib/
+        Passed: 193 macros
+   Test       : Macro syntax of /vnmr/gxyzshim/maclib/
+        Passed: 48 macros
+   Test       : Macro syntax of /vnmr/imaging/maclib/
+        Passed: 459 macros
+   Test       : Macro syntax of /vnmr/maclib/
+        Passed: 2363 macros
+   Test       : Macro syntax of /vnmr/openvnmrj-utils/maclib/
+        Passed: 2 macros
+   Test       : Macro syntax of /vnmr/solidspack/maclib/
+        Passed: 544 macros
+   Test       : Macro syntax of /vnmr/veripulse/maclib/
+        Passed: 168 macros
+   Test       : Tested a total of 5378 macros
+ 
+Parfile rtp tests
+   Test       : Parameter file syntax in /vnmr/biopack/parlib/
+        Passed: 367 parameter sets
+   Test       : Parameter file syntax in /vnmr/biosolidspack/parlib/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-10_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-11_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-12_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-13_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-14_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-15_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-1_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-2_04Oct12_01/dirinfo/parlib/
+        Passed: 2 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-3_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-4_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-5_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-6_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-7_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-8_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-9_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-10_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-11_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-12_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-13_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-14_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-15_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-1_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-2_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-3_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-4_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-7_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-8_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-9_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-10_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-11_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-14_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-15_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-16_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-1_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-2_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-3_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-4_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-5_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-6_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-7_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-8_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-9_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/gxyzshim/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/imaging/ATP/parlib/
+        Passed: 13 parameter sets
+   Test       : Parameter file syntax in /vnmr/imaging/parlib/
+        Passed: 79 parameter sets
+   Test       : Parameter file syntax in /vnmr/parlib/
+        Passed: 242 parameter sets
+   Test       : Parameter file syntax in /vnmr/solidspack/parlib/
+        Passed: 162 parameter sets
+   Test       : Parameter file syntax in /vnmr/veripulse/parlib/
+        Passed: 10 parameter sets
+   Test       : Parameter file syntax in /vnmr/par200/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par200/tests/
+        Passed: 21 parameter sets
+   Test       : Parameter file syntax in /vnmr/par300/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par300/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par400/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par400/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par500/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par500/tests/
+        Passed: 25 parameter sets
+   Test       : Parameter file syntax in /vnmr/par600/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par600/tests/
+        Passed: 24 parameter sets
+   Test       : Parameter file syntax in /vnmr/par700/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par700/tests/
+        Passed: 24 parameter sets
+   Test       : Parameter file syntax in /vnmr/par750/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par750/tests/
+        Passed: 17 parameter sets
+   Test       : Parameter file syntax in /vnmr/par800/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par800/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par900/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par900/tests/
+        Passed: 20 parameter sets
+ 
+XML syntax tests
+   Test       : Xml syntax
+        Passed: 6395 xml files
+ 
+Experiment Menu tests
+   Test       : Experiment menus
+        Passed: 341 experiment menu items
+     ***Failed: 6 experiment menu items
+failed experiment menu item: editht
+failed experiment menu item: noesyHT dps  vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: roesyHT dps  vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: noesyHT dps vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: roesyHT dps vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: Inepthxdec
+        Passed: 344 experiment go('check')
+     ***Failed: 3 experiment go('check')
+go('check') failed for PROTON dn='C13' gHMBCmeAD
+go('check') failed for PROTON gc2hmbcme
+go('check') failed for PROTON gc2h2bcme
+        Passed: 236 experiment exptime
+     ***Failed: 111 experiment exptime
+exptime failed for bashdROESY ()
+exptime failed for zTOCSY1D ()
+exptime failed for ROESY1D ()
+exptime failed for stepNOESY1D ()
+exptime failed for APT ()
+exptime failed for dqcosyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for noesyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for roesyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for dqcosyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for noesyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for roesyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for Hetcortancp2d ()
+exptime failed for Hetcorlgcp2d ()
+exptime failed for Hetcorlgcp2d_1 ()
+exptime failed for Wisetancp2d ()
+exptime failed for Exsy2d ()
+exptime failed for Mashmqc2d ()
+exptime failed for Masapt1d ()
+exptime failed for Mashsqc2d ()
+exptime failed for C7inad2d ()
+exptime failed for Spc5inad2d ()
+exptime failed for Cpinad2d ()
+exptime failed for R14inad2d ()
+exptime failed for Babainad2d ()
+exptime failed for Tancp2drad ()
+exptime failed for Tancp2dspc5 ()
+exptime failed for Pisema2d ()
+exptime failed for Sammy2d ()
+exptime failed for Pisematest1 ()
+exptime failed for Pisematest2 ()
+exptime failed for Lgcp2d ()
+exptime failed for Sc14inad2d ()
+exptime failed for Super2d ()
+exptime failed for Hetcorsamlgcp2d_1 ()
+exptime failed for Hetcorpmlgcp2d_1 ()
+exptime failed for Hetcordumbolgcp2d_1 ()
+exptime failed for Hh2dhdec ()
+exptime failed for IdHetcor ()
+exptime failed for IdInept ()
+exptime failed for Inepthxdec ()
+exptime failed for Tancpxhdec ()
+exptime failed for Tancpxhdeccpmg ()
+exptime failed for Jmasnca2d ()
+exptime failed for Jmasnco2d ()
+exptime failed for Jmascaco2d ()
+exptime failed for Jmascacoipap2d ()
+exptime failed for Jmascacosh2d ()
+exptime failed for Redor1tancp ()
+exptime failed for Redor2tancp ()
+exptime failed for Redor1onepul ()
+exptime failed for Redor2onepul ()
+exptime failed for Fsredor ()
+exptime failed for Dcptan3drad ()
+exptime failed for Dcp2tan3drad ()
+exptime failed for Dcptan3dspc5 ()
+exptime failed for Dcptan ()
+exptime failed for Decorcptan2d ()
+exptime failed for Ineptxyonepul ()
+exptime failed for Ineptxytancp ()
+exptime failed for Ineptxyrefonepul ()
+exptime failed for Ineptxyreftancp ()
+exptime failed for Trapdorycpx ()
+exptime failed for Mrev8 ()
+exptime failed for Mrev8q ()
+exptime failed for Wpmlg1d ()
+exptime failed for Wpmlg2d ()
+exptime failed for C7inadwpmlg2d ()
+exptime failed for Wdumbo1d ()
+exptime failed for Wdumbot1d ()
+exptime failed for C7inadwdumbot2d ()
+exptime failed for C7inadwdumbogen2d ()
+exptime failed for Spsmall ()
+exptime failed for Wpmlgxmx1d ()
+exptime failed for Wdumboxmx1d ()
+exptime failed for Wdumbogen1d ()
+exptime failed for Ssecho1d ()
+exptime failed for Mqmas3qzf2d ()
+exptime failed for Mqmas5qzf2d ()
+exptime failed for Mqmas3q2d ()
+exptime failed for Mqmas3qdfs2d ()
+exptime failed for Mqmas3qdfszf2d ()
+exptime failed for Mqmas3qse2d ()
+exptime failed for Mqmas3qspltse2d ()
+exptime failed for Mqmas3qdfsspltse2d ()
+exptime failed for Mqmas3qfamspltse2d ()
+exptime failed for Mqmas3qfam2spltse2d ()
+exptime failed for Mqmas7qzf2d ()
+exptime failed for Mqmas9qzf2d ()
+exptime failed for Stmas2d ()
+exptime failed for Stmaszf2d ()
+exptime failed for Stmasse2d1 ()
+exptime failed for Stmasse2d2 ()
+exptime failed for Stmasspltse2d1 ()
+exptime failed for Stmasspltse2d2 ()
+exptime failed for Stmasdqfse2d ()
+exptime failed for Stmasdqfspltse2d ()
+exptime failed for Onepuldfs ()
+exptime failed for Onepulsfs ()
+exptime failed for Dipshftr12dfs ()
+exptime failed for Repdfs ()
+exptime failed for Qcpmg1d ()
+exptime failed for Dipshftsr4dfs ()
+exptime failed for Mqmas3qdfs2spltse2d ()
+exptime failed for Trapdor1d ()
+exptime failed for Qcpmgsh1d ()
+exptime failed for Tancpxyr ()
+exptime failed for Onepulxyr ()
+exptime failed for Hetcorlgcp2dxyr ()
+exptime failed for Presto1cp ()
+exptime failed for Presto2cp ()
+exptime failed for Presto3cp ()
+ 
+Libraries for binaries tests
+   Test       : Program ldd test of /vnmr/bin/
+        Passed: 223 programs
+     ***Failed: 7 programs
+failed program: /vnmr/bin/addTables
+failed program: /vnmr/bin/calcFit
+failed program: /vnmr/bin/fidelityFit
+failed program: /vnmr/bin/fidelityPlots
+failed program: /vnmr/bin/matlabPlots
+failed program: /vnmr/bin/powerTables
+failed program: /vnmr/bin/shapeFit
+   Test       : Program ldd test of /vnmr/biopack/BioPack.dir/BP_files/bin/
+   Test       : Program ldd test of /vnmr/biopack/bin/
+        Passed: 14 programs
+   Test       : Program ldd test of /vnmr/craft/bin/
+        Passed: 4 programs
+   Test       : Program ldd test of /vnmr/dicom/bin/
+        Passed: 8 programs
+     ***Failed: 3 programs
+failed program: /vnmr/dicom/bin/echoscu
+failed program: /vnmr/dicom/bin/storescp
+failed program: /vnmr/dicom/bin/storescu
+   Test       : Program ldd test of /vnmr/openvnmrj-utils/bin/
+        Passed: 3 programs
+   Test       : Program ldd test of /vnmr/tcl/bin/
+        Passed: 13 programs
+   Test       : Program ldd test of /vnmr/user_templates/ib_initdir/math/expressions/bin/
+   Test       : Program ldd test of /vnmr/user_templates/ib_initdir/math/functions/bin/
+        Passed: 11 programs
+   Test       : Program ldd test of /vnmr/lib/
+        Passed: 27 programs
+ 
+Linux commands accessed by shell
+   Test       : Access shell commands from /vnmr/autotest/maclib/
+   Test       : Access shell commands from /vnmr/biopack/BioPack.dir/BP_files/maclib/
+   Test       : Access shell commands from /vnmr/biopack/maclib/
+   Test       : Access shell commands from /vnmr/biosolidspack/maclib/
+   Test       : Access shell commands from /vnmr/craft/maclib/
+   Test       : Access shell commands from /vnmr/gxyzshim/maclib/
+   Test       : Access shell commands from /vnmr/imaging/maclib/
+   Test       : Access shell commands from /vnmr/maclib/
+   Test       : Access shell commands from /vnmr/openvnmrj-utils/maclib/
+   Test       : Access shell commands from /vnmr/solidspack/maclib/
+   Test       : Access shell commands from /vnmr/veripulse/maclib/
+   Test       : Access shell commands from /vnmr/menujlib/
+        Passed: 116 shell commands
+     ***Failed: 3 shell commands
+command not found: pr3db
+command not found: acroread
+command not found: sw_vers
+ 
+DSSL test
+   Test       : dssl bug for multiple arrays
+        Passed: 
+ 
+DEA test
+   Test       : DEA integration and baseline correction
+        Passed:  with secondary values
+ 
+PSG tests
+   Test       : Seqgen syntax of /vnmr/autotest/psglib/ with 18 sequences
+        Passed: 18 pulse sequences
+   Test       : Seqgen syntax of /vnmr/biopack/psglib/ with 405 sequences
+        Passed: 405 pulse sequences
+   Test       : Seqgen syntax of /vnmr/biosolidspack/psglib/ with 5 sequences
+        Passed: 5 pulse sequences
+   Test       : Seqgen syntax of /vnmr/gxyzshim/psglib/ with 1 sequences
+        Passed: 1 pulse sequences
+   Test       : Seqgen syntax of /vnmr/imaging/psglib/ with 57 sequences
+        Passed: 57 pulse sequences
+   Test       : Seqgen syntax of /vnmr/psglib/ with 206 sequences
+        Passed: 206 pulse sequences
+   Test       : Seqgen syntax of /vnmr/solidspack/psglib/ with 162 sequences
+        Passed: 162 pulse sequences
+   Test       : Seqgen syntax of /vnmr/veripulse/psglib/ with 1 sequences
+        Passed: 1 pulse sequences
+   Test       : psggen
+        Passed: psggen
+   Test       : fixpsg
+        Passed: fixpsg

--- a/logs/gold_vjqa/vjqa-centos7.txt
+++ b/logs/gold_vjqa/vjqa-centos7.txt
@@ -1,0 +1,360 @@
+ 
+ 
+Start QA testing
+Mar 27 2019 at 22:30:24
+ 
+
+OpenVnmrJ VERSION 1.1 REVISION A
+March 27, 2019
+propulse
+
+OS:
+CentOS Linux release 7.6.1810 (Core) 
+ 
+Installation tests
+   Test       : VnmrJ installation
+     ***Failed: VnmrJ installation
+ 
+Macro syntax tests
+   Test       : Macro syntax of /vnmr/autotest/maclib/
+        Passed: 309 macros
+   Test       : Macro syntax of /vnmr/biopack/BioPack.dir/BP_files/maclib/
+   Test       : Macro syntax of /vnmr/biopack/maclib/
+        Passed: 1052 macros
+   Test       : Macro syntax of /vnmr/biosolidspack/maclib/
+        Passed: 240 macros
+   Test       : Macro syntax of /vnmr/craft/maclib/
+        Passed: 193 macros
+   Test       : Macro syntax of /vnmr/gxyzshim/maclib/
+        Passed: 48 macros
+   Test       : Macro syntax of /vnmr/imaging/maclib/
+        Passed: 459 macros
+   Test       : Macro syntax of /vnmr/maclib/
+        Passed: 2363 macros
+   Test       : Macro syntax of /vnmr/openvnmrj-utils/maclib/
+        Passed: 2 macros
+   Test       : Macro syntax of /vnmr/solidspack/maclib/
+        Passed: 544 macros
+   Test       : Macro syntax of /vnmr/veripulse/maclib/
+        Passed: 168 macros
+   Test       : Tested a total of 5378 macros
+ 
+Parfile rtp tests
+   Test       : Parameter file syntax in /vnmr/biopack/parlib/
+        Passed: 367 parameter sets
+   Test       : Parameter file syntax in /vnmr/biosolidspack/parlib/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-10_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-11_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-12_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-13_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-14_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-15_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-1_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-2_04Oct12_01/dirinfo/parlib/
+        Passed: 2 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-3_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-4_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-5_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-6_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-7_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-8_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-9_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-10_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-11_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-12_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-13_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-14_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-15_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-1_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-2_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-3_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-4_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-7_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-8_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-9_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-10_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-11_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-14_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-15_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-16_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-1_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-2_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-3_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-4_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-5_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-6_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-7_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-8_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-9_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/gxyzshim/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/imaging/ATP/parlib/
+        Passed: 13 parameter sets
+   Test       : Parameter file syntax in /vnmr/imaging/parlib/
+        Passed: 79 parameter sets
+   Test       : Parameter file syntax in /vnmr/parlib/
+        Passed: 242 parameter sets
+   Test       : Parameter file syntax in /vnmr/solidspack/parlib/
+        Passed: 162 parameter sets
+   Test       : Parameter file syntax in /vnmr/veripulse/parlib/
+        Passed: 10 parameter sets
+   Test       : Parameter file syntax in /vnmr/par200/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par200/tests/
+        Passed: 21 parameter sets
+   Test       : Parameter file syntax in /vnmr/par300/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par300/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par400/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par400/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par500/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par500/tests/
+        Passed: 25 parameter sets
+   Test       : Parameter file syntax in /vnmr/par600/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par600/tests/
+        Passed: 24 parameter sets
+   Test       : Parameter file syntax in /vnmr/par700/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par700/tests/
+        Passed: 24 parameter sets
+   Test       : Parameter file syntax in /vnmr/par750/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par750/tests/
+        Passed: 17 parameter sets
+   Test       : Parameter file syntax in /vnmr/par800/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par800/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par900/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par900/tests/
+        Passed: 20 parameter sets
+ 
+XML syntax tests
+   Test       : Xml syntax
+        Passed: 6398 xml files
+ 
+Experiment Menu tests
+   Test       : Experiment menus
+        Passed: 341 experiment menu items
+     ***Failed: 6 experiment menu items
+failed experiment menu item: editht
+failed experiment menu item: noesyHT dps  vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: roesyHT dps  vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: noesyHT dps vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: roesyHT dps vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: Inepthxdec
+        Passed: 344 experiment go('check')
+     ***Failed: 3 experiment go('check')
+go('check') failed for PROTON dn='C13' gHMBCmeAD
+go('check') failed for PROTON gc2hmbcme
+go('check') failed for PROTON gc2h2bcme
+        Passed: 268 experiment exptime
+     ***Failed: 79 experiment exptime
+exptime failed for bashdROESY ()
+exptime failed for zTOCSY1D ()
+exptime failed for ROESY1D ()
+exptime failed for stepNOESY1D ()
+exptime failed for APT ()
+exptime failed for dqcosyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for noesyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for roesyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for dqcosyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for noesyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for roesyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for Hetcortancp2d ()
+exptime failed for Hetcorlgcp2d ()
+exptime failed for Hetcorlgcp2d_1 ()
+exptime failed for Wisetancp2d ()
+exptime failed for Exsy2d ()
+exptime failed for Mashmqc2d ()
+exptime failed for Masapt1d ()
+exptime failed for Mashsqc2d ()
+exptime failed for C7inad2d ()
+exptime failed for Spc5inad2d ()
+exptime failed for Cpinad2d ()
+exptime failed for R14inad2d ()
+exptime failed for Babainad2d ()
+exptime failed for Tancp2drad ()
+exptime failed for Tancp2dspc5 ()
+exptime failed for Pisema2d ()
+exptime failed for Sammy2d ()
+exptime failed for Pisematest1 ()
+exptime failed for Pisematest2 ()
+exptime failed for Lgcp2d ()
+exptime failed for Sc14inad2d ()
+exptime failed for Super2d ()
+exptime failed for Hetcorsamlgcp2d_1 ()
+exptime failed for Hetcorpmlgcp2d_1 ()
+exptime failed for Hetcordumbolgcp2d_1 ()
+exptime failed for Hh2dhdec ()
+exptime failed for IdHetcor ()
+exptime failed for IdInept ()
+exptime failed for Inepthxdec ()
+exptime failed for Tancpxhdec ()
+exptime failed for Tancpxhdeccpmg ()
+exptime failed for Jmasnca2d ()
+exptime failed for Jmasnco2d ()
+exptime failed for Jmascaco2d ()
+exptime failed for Jmascacoipap2d ()
+exptime failed for Jmascacosh2d ()
+exptime failed for Redor1tancp ()
+exptime failed for Redor2tancp ()
+exptime failed for Redor1onepul ()
+exptime failed for Redor2onepul ()
+exptime failed for Fsredor ()
+exptime failed for Dcptan3drad ()
+exptime failed for Dcp2tan3drad ()
+exptime failed for Dcptan3dspc5 ()
+exptime failed for Dcptan ()
+exptime failed for Decorcptan2d ()
+exptime failed for Ineptxyonepul ()
+exptime failed for Ineptxytancp ()
+exptime failed for Ineptxyrefonepul ()
+exptime failed for Ineptxyreftancp ()
+exptime failed for Trapdorycpx ()
+exptime failed for Mrev8 ()
+exptime failed for Mrev8q ()
+exptime failed for Wpmlg1d ()
+exptime failed for Wpmlg2d ()
+exptime failed for C7inadwpmlg2d ()
+exptime failed for Wdumbo1d ()
+exptime failed for Wdumbot1d ()
+exptime failed for C7inadwdumbot2d ()
+exptime failed for C7inadwdumbogen2d ()
+exptime failed for Spsmall ()
+exptime failed for Wpmlgxmx1d ()
+exptime failed for Wdumboxmx1d ()
+exptime failed for Wdumbogen1d ()
+exptime failed for Qcpmgsh1d ()
+exptime failed for Presto1cp ()
+exptime failed for Presto2cp ()
+exptime failed for Presto3cp ()
+ 
+Libraries for binaries tests
+   Test       : Program ldd test of /vnmr/bin/
+        Passed: 223 programs
+     ***Failed: 7 programs
+failed program: /vnmr/bin/addTables
+failed program: /vnmr/bin/calcFit
+failed program: /vnmr/bin/fidelityFit
+failed program: /vnmr/bin/fidelityPlots
+failed program: /vnmr/bin/matlabPlots
+failed program: /vnmr/bin/powerTables
+failed program: /vnmr/bin/shapeFit
+   Test       : Program ldd test of /vnmr/biopack/BioPack.dir/BP_files/bin/
+   Test       : Program ldd test of /vnmr/biopack/bin/
+        Passed: 14 programs
+   Test       : Program ldd test of /vnmr/craft/bin/
+        Passed: 4 programs
+   Test       : Program ldd test of /vnmr/dicom/bin/
+        Passed: 8 programs
+     ***Failed: 3 programs
+failed program: /vnmr/dicom/bin/echoscu
+failed program: /vnmr/dicom/bin/storescp
+failed program: /vnmr/dicom/bin/storescu
+   Test       : Program ldd test of /vnmr/openvnmrj-utils/bin/
+        Passed: 3 programs
+   Test       : Program ldd test of /vnmr/tcl/bin/
+        Passed: 13 programs
+   Test       : Program ldd test of /vnmr/user_templates/ib_initdir/math/expressions/bin/
+   Test       : Program ldd test of /vnmr/user_templates/ib_initdir/math/functions/bin/
+        Passed: 11 programs
+   Test       : Program ldd test of /vnmr/lib/
+        Passed: 27 programs
+ 
+Linux commands accessed by shell
+   Test       : Access shell commands from /vnmr/autotest/maclib/
+   Test       : Access shell commands from /vnmr/biopack/BioPack.dir/BP_files/maclib/
+   Test       : Access shell commands from /vnmr/biopack/maclib/
+   Test       : Access shell commands from /vnmr/biosolidspack/maclib/
+   Test       : Access shell commands from /vnmr/craft/maclib/
+   Test       : Access shell commands from /vnmr/gxyzshim/maclib/
+   Test       : Access shell commands from /vnmr/imaging/maclib/
+   Test       : Access shell commands from /vnmr/maclib/
+   Test       : Access shell commands from /vnmr/openvnmrj-utils/maclib/
+   Test       : Access shell commands from /vnmr/solidspack/maclib/
+   Test       : Access shell commands from /vnmr/veripulse/maclib/
+   Test       : Access shell commands from /vnmr/menujlib/
+        Passed: 116 shell commands
+     ***Failed: 3 shell commands
+command not found: pr3db
+command not found: acroread
+command not found: sw_vers
+ 
+DSSL test
+   Test       : dssl bug for multiple arrays
+        Passed: 
+ 
+DEA test
+   Test       : DEA integration and baseline correction
+        Passed:  with secondary values
+ 
+PSG tests
+   Test       : Seqgen syntax of /vnmr/autotest/psglib/ with 18 sequences
+        Passed: 18 pulse sequences
+   Test       : Seqgen syntax of /vnmr/biopack/psglib/ with 405 sequences
+        Passed: 405 pulse sequences
+   Test       : Seqgen syntax of /vnmr/biosolidspack/psglib/ with 5 sequences
+        Passed: 5 pulse sequences
+   Test       : Seqgen syntax of /vnmr/gxyzshim/psglib/ with 1 sequences
+        Passed: 1 pulse sequences
+   Test       : Seqgen syntax of /vnmr/imaging/psglib/ with 57 sequences
+        Passed: 57 pulse sequences
+   Test       : Seqgen syntax of /vnmr/psglib/ with 206 sequences
+        Passed: 206 pulse sequences
+   Test       : Seqgen syntax of /vnmr/solidspack/psglib/ with 162 sequences
+        Passed: 162 pulse sequences
+   Test       : Seqgen syntax of /vnmr/veripulse/psglib/ with 1 sequences
+        Passed: 1 pulse sequences
+   Test       : psggen
+        Passed: psggen
+   Test       : fixpsg
+        Passed: fixpsg

--- a/logs/gold_vjqa/vjqa-mint19.txt
+++ b/logs/gold_vjqa/vjqa-mint19.txt
@@ -1,0 +1,361 @@
+ 
+ 
+Start QA testing
+Mar 27 2019 at 23:55:06
+ 
+
+OpenVnmrJ VERSION 1.1 REVISION A
+March 27, 2019
+propulse
+
+OS:
+Linux Mint 19
+ 
+Installation tests
+   Test       : VnmrJ installation
+     ***Failed: VnmrJ installation
+ 
+Macro syntax tests
+   Test       : Macro syntax of /vnmr/autotest/maclib/
+        Passed: 309 macros
+   Test       : Macro syntax of /vnmr/biopack/BioPack.dir/BP_files/maclib/
+   Test       : Macro syntax of /vnmr/biopack/maclib/
+        Passed: 1052 macros
+   Test       : Macro syntax of /vnmr/biosolidspack/maclib/
+        Passed: 240 macros
+   Test       : Macro syntax of /vnmr/craft/maclib/
+        Passed: 193 macros
+   Test       : Macro syntax of /vnmr/gxyzshim/maclib/
+        Passed: 48 macros
+   Test       : Macro syntax of /vnmr/imaging/maclib/
+        Passed: 459 macros
+   Test       : Macro syntax of /vnmr/maclib/
+        Passed: 2363 macros
+   Test       : Macro syntax of /vnmr/openvnmrj-utils/maclib/
+        Passed: 2 macros
+   Test       : Macro syntax of /vnmr/solidspack/maclib/
+        Passed: 544 macros
+   Test       : Macro syntax of /vnmr/veripulse/maclib/
+        Passed: 168 macros
+   Test       : Tested a total of 5378 macros
+ 
+Parfile rtp tests
+   Test       : Parameter file syntax in /vnmr/biopack/parlib/
+        Passed: 367 parameter sets
+   Test       : Parameter file syntax in /vnmr/biosolidspack/parlib/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-10_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-11_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-12_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-13_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-14_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-15_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-1_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-2_04Oct12_01/dirinfo/parlib/
+        Passed: 2 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-3_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-4_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-5_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-6_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-7_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-8_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-9_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-10_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-11_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-12_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-13_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-14_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-15_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-1_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-2_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-3_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-4_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-7_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-8_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-9_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-10_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-11_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-14_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-15_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-16_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-1_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-2_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-3_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-4_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-5_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-6_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-7_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-8_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-9_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/gxyzshim/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/imaging/ATP/parlib/
+        Passed: 13 parameter sets
+   Test       : Parameter file syntax in /vnmr/imaging/parlib/
+        Passed: 79 parameter sets
+   Test       : Parameter file syntax in /vnmr/parlib/
+        Passed: 242 parameter sets
+   Test       : Parameter file syntax in /vnmr/solidspack/parlib/
+        Passed: 162 parameter sets
+   Test       : Parameter file syntax in /vnmr/veripulse/parlib/
+        Passed: 10 parameter sets
+   Test       : Parameter file syntax in /vnmr/par200/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par200/tests/
+        Passed: 21 parameter sets
+   Test       : Parameter file syntax in /vnmr/par300/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par300/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par400/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par400/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par500/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par500/tests/
+        Passed: 25 parameter sets
+   Test       : Parameter file syntax in /vnmr/par600/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par600/tests/
+        Passed: 24 parameter sets
+   Test       : Parameter file syntax in /vnmr/par700/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par700/tests/
+        Passed: 24 parameter sets
+   Test       : Parameter file syntax in /vnmr/par750/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par750/tests/
+        Passed: 17 parameter sets
+   Test       : Parameter file syntax in /vnmr/par800/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par800/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par900/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par900/tests/
+        Passed: 20 parameter sets
+ 
+XML syntax tests
+   Test       : Xml syntax
+        Passed: 6395 xml files
+ 
+Experiment Menu tests
+   Test       : Experiment menus
+        Passed: 341 experiment menu items
+     ***Failed: 6 experiment menu items
+failed experiment menu item: editht
+failed experiment menu item: noesyHT dps  vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: roesyHT dps  vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: noesyHT dps vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: roesyHT dps vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: Inepthxdec
+        Passed: 344 experiment go('check')
+     ***Failed: 3 experiment go('check')
+go('check') failed for PROTON dn='C13' gHMBCmeAD
+go('check') failed for PROTON gc2hmbcme
+go('check') failed for PROTON gc2h2bcme
+        Passed: 271 experiment exptime
+     ***Failed: 76 experiment exptime
+exptime failed for bashdROESY ()
+exptime failed for zTOCSY1D ()
+exptime failed for ROESY1D ()
+exptime failed for stepNOESY1D ()
+exptime failed for APT ()
+exptime failed for dqcosyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for noesyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for roesyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for dqcosyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for noesyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for roesyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for Hetcortancp2d ()
+exptime failed for Hetcorlgcp2d ()
+exptime failed for Hetcorlgcp2d_1 ()
+exptime failed for Wisetancp2d ()
+exptime failed for Exsy2d ()
+exptime failed for Mashmqc2d ()
+exptime failed for Masapt1d ()
+exptime failed for Mashsqc2d ()
+exptime failed for C7inad2d ()
+exptime failed for Spc5inad2d ()
+exptime failed for Cpinad2d ()
+exptime failed for R14inad2d ()
+exptime failed for Babainad2d ()
+exptime failed for Tancp2drad ()
+exptime failed for Tancp2dspc5 ()
+exptime failed for Pisema2d ()
+exptime failed for Sammy2d ()
+exptime failed for Pisematest1 ()
+exptime failed for Pisematest2 ()
+exptime failed for Lgcp2d ()
+exptime failed for Sc14inad2d ()
+exptime failed for Super2d ()
+exptime failed for Hetcorsamlgcp2d_1 ()
+exptime failed for Hetcorpmlgcp2d_1 ()
+exptime failed for Hetcordumbolgcp2d_1 ()
+exptime failed for Hh2dhdec ()
+exptime failed for IdHetcor ()
+exptime failed for IdInept ()
+exptime failed for Inepthxdec ()
+exptime failed for Tancpxhdec ()
+exptime failed for Tancpxhdeccpmg ()
+exptime failed for Jmasnca2d ()
+exptime failed for Jmasnco2d ()
+exptime failed for Jmascaco2d ()
+exptime failed for Jmascacoipap2d ()
+exptime failed for Jmascacosh2d ()
+exptime failed for Redor1tancp ()
+exptime failed for Redor2tancp ()
+exptime failed for Redor1onepul ()
+exptime failed for Redor2onepul ()
+exptime failed for Fsredor ()
+exptime failed for Dcptan3drad ()
+exptime failed for Dcp2tan3drad ()
+exptime failed for Dcptan3dspc5 ()
+exptime failed for Dcptan ()
+exptime failed for Decorcptan2d ()
+exptime failed for Ineptxyonepul ()
+exptime failed for Ineptxytancp ()
+exptime failed for Ineptxyrefonepul ()
+exptime failed for Ineptxyreftancp ()
+exptime failed for Trapdorycpx ()
+exptime failed for Mrev8 ()
+exptime failed for Mrev8q ()
+exptime failed for Wpmlg1d ()
+exptime failed for Wpmlg2d ()
+exptime failed for C7inadwpmlg2d ()
+exptime failed for Wdumbo1d ()
+exptime failed for Wdumbot1d ()
+exptime failed for C7inadwdumbot2d ()
+exptime failed for C7inadwdumbogen2d ()
+exptime failed for Spsmall ()
+exptime failed for Wpmlgxmx1d ()
+exptime failed for Wdumboxmx1d ()
+exptime failed for Wdumbogen1d ()
+exptime failed for Qcpmgsh1d ()
+ 
+Libraries for binaries tests
+   Test       : Program ldd test of /vnmr/bin/
+        Passed: 211 programs
+     ***Failed: 8 programs
+failed program: /vnmr/bin/addTables
+failed program: /vnmr/bin/calcFit
+failed program: /vnmr/bin/fidelityFit
+failed program: /vnmr/bin/fidelityPlots
+failed program: /vnmr/bin/kermit
+failed program: /vnmr/bin/matlabPlots
+failed program: /vnmr/bin/powerTables
+failed program: /vnmr/bin/shapeFit
+   Test       : Program ldd test of /vnmr/biopack/BioPack.dir/BP_files/bin/
+   Test       : Program ldd test of /vnmr/biopack/bin/
+        Passed: 14 programs
+   Test       : Program ldd test of /vnmr/craft/bin/
+        Passed: 4 programs
+   Test       : Program ldd test of /vnmr/dicom/bin/
+        Passed: 8 programs
+     ***Failed: 3 programs
+failed program: /vnmr/dicom/bin/echoscu
+failed program: /vnmr/dicom/bin/storescp
+failed program: /vnmr/dicom/bin/storescu
+   Test       : Program ldd test of /vnmr/openvnmrj-utils/bin/
+        Passed: 3 programs
+   Test       : Program ldd test of /vnmr/tcl/bin/
+        Passed: 13 programs
+   Test       : Program ldd test of /vnmr/user_templates/ib_initdir/math/expressions/bin/
+   Test       : Program ldd test of /vnmr/user_templates/ib_initdir/math/functions/bin/
+        Passed: 11 programs
+   Test       : Program ldd test of /vnmr/lib/
+        Passed: 27 programs
+ 
+Linux commands accessed by shell
+   Test       : Access shell commands from /vnmr/autotest/maclib/
+   Test       : Access shell commands from /vnmr/biopack/BioPack.dir/BP_files/maclib/
+   Test       : Access shell commands from /vnmr/biopack/maclib/
+   Test       : Access shell commands from /vnmr/biosolidspack/maclib/
+   Test       : Access shell commands from /vnmr/craft/maclib/
+   Test       : Access shell commands from /vnmr/gxyzshim/maclib/
+   Test       : Access shell commands from /vnmr/imaging/maclib/
+   Test       : Access shell commands from /vnmr/maclib/
+   Test       : Access shell commands from /vnmr/openvnmrj-utils/maclib/
+   Test       : Access shell commands from /vnmr/solidspack/maclib/
+   Test       : Access shell commands from /vnmr/veripulse/maclib/
+   Test       : Access shell commands from /vnmr/menujlib/
+        Passed: 113 shell commands
+     ***Failed: 6 shell commands
+command not found: pr3db
+command not found: acroread
+command not found: /bin/gawk
+command not found: sw_vers
+command not found: xterm
+command not found: nautilus
+ 
+DSSL test
+   Test       : dssl bug for multiple arrays
+        Passed: 
+ 
+DEA test
+   Test       : DEA integration and baseline correction
+     ***Failed: Dea test: 98.03 +/-0.34% (7 of 8 integrals)
+ 
+PSG tests
+   Test       : Seqgen syntax of /vnmr/autotest/psglib/ with 18 sequences
+        Passed: 18 pulse sequences
+   Test       : Seqgen syntax of /vnmr/biopack/psglib/ with 405 sequences
+        Passed: 405 pulse sequences
+   Test       : Seqgen syntax of /vnmr/biosolidspack/psglib/ with 5 sequences
+        Passed: 5 pulse sequences
+   Test       : Seqgen syntax of /vnmr/gxyzshim/psglib/ with 1 sequences
+        Passed: 1 pulse sequences
+   Test       : Seqgen syntax of /vnmr/imaging/psglib/ with 57 sequences
+        Passed: 57 pulse sequences
+   Test       : Seqgen syntax of /vnmr/psglib/ with 206 sequences
+        Passed: 206 pulse sequences
+   Test       : Seqgen syntax of /vnmr/solidspack/psglib/ with 162 sequences
+        Passed: 162 pulse sequences
+   Test       : Seqgen syntax of /vnmr/veripulse/psglib/ with 1 sequences
+        Passed: 1 pulse sequences
+   Test       : psggen
+        Passed: psggen
+   Test       : fixpsg
+        Passed: fixpsg

--- a/logs/gold_vjqa/vjqa-ubuntu14.txt
+++ b/logs/gold_vjqa/vjqa-ubuntu14.txt
@@ -1,0 +1,368 @@
+ 
+ 
+Start QA testing
+Mar 28 2019 at 01:12:56
+ 
+
+OpenVnmrJ VERSION 1.1 REVISION A
+March 28, 2019
+propulse
+
+OS:
+Ubuntu 14.04.6 LTS
+ 
+Installation tests
+   Test       : VnmrJ installation
+     ***Failed: VnmrJ installation
+ 
+Macro syntax tests
+   Test       : Macro syntax of /vnmr/autotest/maclib/
+        Passed: 309 macros
+   Test       : Macro syntax of /vnmr/biopack/BioPack.dir/BP_files/maclib/
+   Test       : Macro syntax of /vnmr/biopack/maclib/
+        Passed: 1052 macros
+   Test       : Macro syntax of /vnmr/biosolidspack/maclib/
+        Passed: 240 macros
+   Test       : Macro syntax of /vnmr/craft/maclib/
+        Passed: 193 macros
+   Test       : Macro syntax of /vnmr/gxyzshim/maclib/
+        Passed: 48 macros
+   Test       : Macro syntax of /vnmr/imaging/maclib/
+        Passed: 459 macros
+   Test       : Macro syntax of /vnmr/maclib/
+        Passed: 2363 macros
+   Test       : Macro syntax of /vnmr/openvnmrj-utils/maclib/
+        Passed: 2 macros
+   Test       : Macro syntax of /vnmr/solidspack/maclib/
+        Passed: 544 macros
+   Test       : Macro syntax of /vnmr/veripulse/maclib/
+        Passed: 168 macros
+   Test       : Tested a total of 5378 macros
+ 
+Parfile rtp tests
+   Test       : Parameter file syntax in /vnmr/biopack/parlib/
+        Passed: 367 parameter sets
+   Test       : Parameter file syntax in /vnmr/biosolidspack/parlib/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-10_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-11_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-12_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-13_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-14_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-15_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-1_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-2_04Oct12_01/dirinfo/parlib/
+        Passed: 2 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-3_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-4_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-5_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-6_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-7_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-8_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-9_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-10_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-11_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-12_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-13_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-14_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-15_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-1_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-2_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-3_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-4_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-7_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-8_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-9_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-10_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-11_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-14_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-15_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-16_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-1_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-2_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-3_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-4_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-5_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-6_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-7_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-8_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-9_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/gxyzshim/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/imaging/ATP/parlib/
+        Passed: 13 parameter sets
+   Test       : Parameter file syntax in /vnmr/imaging/parlib/
+        Passed: 79 parameter sets
+   Test       : Parameter file syntax in /vnmr/parlib/
+        Passed: 242 parameter sets
+   Test       : Parameter file syntax in /vnmr/solidspack/parlib/
+        Passed: 162 parameter sets
+   Test       : Parameter file syntax in /vnmr/veripulse/parlib/
+        Passed: 10 parameter sets
+   Test       : Parameter file syntax in /vnmr/par200/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par200/tests/
+        Passed: 21 parameter sets
+   Test       : Parameter file syntax in /vnmr/par300/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par300/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par400/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par400/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par500/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par500/tests/
+        Passed: 25 parameter sets
+   Test       : Parameter file syntax in /vnmr/par600/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par600/tests/
+        Passed: 24 parameter sets
+   Test       : Parameter file syntax in /vnmr/par700/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par700/tests/
+        Passed: 24 parameter sets
+   Test       : Parameter file syntax in /vnmr/par750/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par750/tests/
+        Passed: 17 parameter sets
+   Test       : Parameter file syntax in /vnmr/par800/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par800/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par900/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par900/tests/
+        Passed: 20 parameter sets
+ 
+XML syntax tests
+   Test       : Xml syntax
+        Passed: 6398 xml files
+ 
+Experiment Menu tests
+   Test       : Experiment menus
+        Passed: 341 experiment menu items
+     ***Failed: 6 experiment menu items
+failed experiment menu item: editht
+failed experiment menu item: noesyHT dps  vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: roesyHT dps  vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: noesyHT dps vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: roesyHT dps vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: Inepthxdec
+        Passed: 344 experiment go('check')
+     ***Failed: 3 experiment go('check')
+go('check') failed for PROTON dn='C13' gHMBCmeAD
+go('check') failed for PROTON gc2hmbcme
+go('check') failed for PROTON gc2h2bcme
+        Passed: 271 experiment exptime
+     ***Failed: 76 experiment exptime
+exptime failed for bashdROESY ()
+exptime failed for zTOCSY1D ()
+exptime failed for ROESY1D ()
+exptime failed for stepNOESY1D ()
+exptime failed for APT ()
+exptime failed for dqcosyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for noesyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for roesyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for dqcosyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for noesyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for roesyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for Hetcortancp2d ()
+exptime failed for Hetcorlgcp2d ()
+exptime failed for Hetcorlgcp2d_1 ()
+exptime failed for Wisetancp2d ()
+exptime failed for Exsy2d ()
+exptime failed for Mashmqc2d ()
+exptime failed for Masapt1d ()
+exptime failed for Mashsqc2d ()
+exptime failed for C7inad2d ()
+exptime failed for Spc5inad2d ()
+exptime failed for Cpinad2d ()
+exptime failed for R14inad2d ()
+exptime failed for Babainad2d ()
+exptime failed for Tancp2drad ()
+exptime failed for Tancp2dspc5 ()
+exptime failed for Pisema2d ()
+exptime failed for Sammy2d ()
+exptime failed for Pisematest1 ()
+exptime failed for Pisematest2 ()
+exptime failed for Lgcp2d ()
+exptime failed for Sc14inad2d ()
+exptime failed for Super2d ()
+exptime failed for Hetcorsamlgcp2d_1 ()
+exptime failed for Hetcorpmlgcp2d_1 ()
+exptime failed for Hetcordumbolgcp2d_1 ()
+exptime failed for Hh2dhdec ()
+exptime failed for IdHetcor ()
+exptime failed for IdInept ()
+exptime failed for Inepthxdec ()
+exptime failed for Tancpxhdec ()
+exptime failed for Tancpxhdeccpmg ()
+exptime failed for Jmasnca2d ()
+exptime failed for Jmasnco2d ()
+exptime failed for Jmascaco2d ()
+exptime failed for Jmascacoipap2d ()
+exptime failed for Jmascacosh2d ()
+exptime failed for Redor1tancp ()
+exptime failed for Redor2tancp ()
+exptime failed for Redor1onepul ()
+exptime failed for Redor2onepul ()
+exptime failed for Fsredor ()
+exptime failed for Dcptan3drad ()
+exptime failed for Dcp2tan3drad ()
+exptime failed for Dcptan3dspc5 ()
+exptime failed for Dcptan ()
+exptime failed for Decorcptan2d ()
+exptime failed for Ineptxyonepul ()
+exptime failed for Ineptxytancp ()
+exptime failed for Ineptxyrefonepul ()
+exptime failed for Ineptxyreftancp ()
+exptime failed for Trapdorycpx ()
+exptime failed for Mrev8 ()
+exptime failed for Mrev8q ()
+exptime failed for Wpmlg1d ()
+exptime failed for Wpmlg2d ()
+exptime failed for C7inadwpmlg2d ()
+exptime failed for Wdumbo1d ()
+exptime failed for Wdumbot1d ()
+exptime failed for C7inadwdumbot2d ()
+exptime failed for C7inadwdumbogen2d ()
+exptime failed for Spsmall ()
+exptime failed for Wpmlgxmx1d ()
+exptime failed for Wdumboxmx1d ()
+exptime failed for Wdumbogen1d ()
+exptime failed for Qcpmgsh1d ()
+ 
+Libraries for binaries tests
+   Test       : Program ldd test of /vnmr/bin/
+        Passed: 222 programs
+     ***Failed: 8 programs
+failed program: /vnmr/bin/addTables
+failed program: /vnmr/bin/calcFit
+failed program: /vnmr/bin/fidelityFit
+failed program: /vnmr/bin/fidelityPlots
+failed program: /vnmr/bin/kermit
+failed program: /vnmr/bin/matlabPlots
+failed program: /vnmr/bin/powerTables
+failed program: /vnmr/bin/shapeFit
+   Test       : Program ldd test of /vnmr/biopack/BioPack.dir/BP_files/bin/
+   Test       : Program ldd test of /vnmr/biopack/bin/
+        Passed: 14 programs
+   Test       : Program ldd test of /vnmr/craft/bin/
+        Passed: 4 programs
+   Test       : Program ldd test of /vnmr/dicom/bin/
+        Passed: 8 programs
+     ***Failed: 3 programs
+failed program: /vnmr/dicom/bin/echoscu
+failed program: /vnmr/dicom/bin/storescp
+failed program: /vnmr/dicom/bin/storescu
+   Test       : Program ldd test of /vnmr/openvnmrj-utils/bin/
+        Passed: 3 programs
+   Test       : Program ldd test of /vnmr/tcl/bin/
+        Passed: 13 programs
+   Test       : Program ldd test of /vnmr/user_templates/ib_initdir/math/expressions/bin/
+   Test       : Program ldd test of /vnmr/user_templates/ib_initdir/math/functions/bin/
+        Passed: 11 programs
+   Test       : Program ldd test of /vnmr/lib/
+        Passed: 27 programs
+ 
+Linux commands accessed by shell
+   Test       : Access shell commands from /vnmr/autotest/maclib/
+   Test       : Access shell commands from /vnmr/biopack/BioPack.dir/BP_files/maclib/
+   Test       : Access shell commands from /vnmr/biopack/maclib/
+   Test       : Access shell commands from /vnmr/biosolidspack/maclib/
+   Test       : Access shell commands from /vnmr/craft/maclib/
+   Test       : Access shell commands from /vnmr/gxyzshim/maclib/
+   Test       : Access shell commands from /vnmr/imaging/maclib/
+   Test       : Access shell commands from /vnmr/maclib/
+   Test       : Access shell commands from /vnmr/openvnmrj-utils/maclib/
+   Test       : Access shell commands from /vnmr/solidspack/maclib/
+   Test       : Access shell commands from /vnmr/veripulse/maclib/
+   Test       : Access shell commands from /vnmr/menujlib/
+        Passed: 106 shell commands
+     ***Failed: 13 shell commands
+command not found: gnuplot
+command not found: pr3db
+command not found: enscript
+command not found: acroread
+command not found: gedit
+command not found: gnome-terminal
+command not found: /bin/gawk
+command not found: zip
+command not found: sw_vers
+command not found: lp
+command not found: dos2unix
+command not found: xterm
+command not found: nautilus
+ 
+DSSL test
+   Test       : dssl bug for multiple arrays
+        Passed: 
+ 
+DEA test
+   Test       : DEA integration and baseline correction
+        Passed:  with secondary values
+ 
+PSG tests
+   Test       : Seqgen syntax of /vnmr/autotest/psglib/ with 18 sequences
+        Passed: 18 pulse sequences
+   Test       : Seqgen syntax of /vnmr/biopack/psglib/ with 405 sequences
+        Passed: 405 pulse sequences
+   Test       : Seqgen syntax of /vnmr/biosolidspack/psglib/ with 5 sequences
+        Passed: 5 pulse sequences
+   Test       : Seqgen syntax of /vnmr/gxyzshim/psglib/ with 1 sequences
+        Passed: 1 pulse sequences
+   Test       : Seqgen syntax of /vnmr/imaging/psglib/ with 57 sequences
+        Passed: 57 pulse sequences
+   Test       : Seqgen syntax of /vnmr/psglib/ with 206 sequences
+        Passed: 206 pulse sequences
+   Test       : Seqgen syntax of /vnmr/solidspack/psglib/ with 162 sequences
+        Passed: 162 pulse sequences
+   Test       : Seqgen syntax of /vnmr/veripulse/psglib/ with 1 sequences
+        Passed: 1 pulse sequences
+   Test       : psggen
+        Passed: psggen
+   Test       : fixpsg
+        Passed: fixpsg

--- a/logs/gold_vjqa/vjqa-ubuntu16.txt
+++ b/logs/gold_vjqa/vjqa-ubuntu16.txt
@@ -1,0 +1,362 @@
+ 
+ 
+Start QA testing
+Mar 28 2019 at 02:35:37
+ 
+
+OpenVnmrJ VERSION 1.1 REVISION A
+March 28, 2019
+propulse
+
+OS:
+Ubuntu 16.04.6 LTS
+ 
+Installation tests
+   Test       : VnmrJ installation
+     ***Failed: VnmrJ installation
+ 
+Macro syntax tests
+   Test       : Macro syntax of /vnmr/autotest/maclib/
+        Passed: 309 macros
+   Test       : Macro syntax of /vnmr/biopack/BioPack.dir/BP_files/maclib/
+   Test       : Macro syntax of /vnmr/biopack/maclib/
+        Passed: 1052 macros
+   Test       : Macro syntax of /vnmr/biosolidspack/maclib/
+        Passed: 240 macros
+   Test       : Macro syntax of /vnmr/craft/maclib/
+        Passed: 193 macros
+   Test       : Macro syntax of /vnmr/gxyzshim/maclib/
+        Passed: 48 macros
+   Test       : Macro syntax of /vnmr/imaging/maclib/
+        Passed: 459 macros
+   Test       : Macro syntax of /vnmr/maclib/
+        Passed: 2363 macros
+   Test       : Macro syntax of /vnmr/openvnmrj-utils/maclib/
+        Passed: 2 macros
+   Test       : Macro syntax of /vnmr/solidspack/maclib/
+        Passed: 544 macros
+   Test       : Macro syntax of /vnmr/veripulse/maclib/
+        Passed: 168 macros
+   Test       : Tested a total of 5378 macros
+ 
+Parfile rtp tests
+   Test       : Parameter file syntax in /vnmr/biopack/parlib/
+        Passed: 367 parameter sets
+   Test       : Parameter file syntax in /vnmr/biosolidspack/parlib/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-10_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-11_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-12_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-13_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-14_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-15_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-1_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-2_04Oct12_01/dirinfo/parlib/
+        Passed: 2 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-3_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-4_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-5_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-6_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-7_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-8_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-9_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-10_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-11_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-12_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-13_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-14_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-15_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-1_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-2_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-3_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-4_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-7_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-8_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-9_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-10_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-11_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-14_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-15_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-16_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-1_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-2_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-3_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-4_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-5_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-6_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-7_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-8_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-9_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/gxyzshim/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/imaging/ATP/parlib/
+        Passed: 13 parameter sets
+   Test       : Parameter file syntax in /vnmr/imaging/parlib/
+        Passed: 79 parameter sets
+   Test       : Parameter file syntax in /vnmr/parlib/
+        Passed: 242 parameter sets
+   Test       : Parameter file syntax in /vnmr/solidspack/parlib/
+        Passed: 162 parameter sets
+   Test       : Parameter file syntax in /vnmr/veripulse/parlib/
+        Passed: 10 parameter sets
+   Test       : Parameter file syntax in /vnmr/par200/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par200/tests/
+        Passed: 21 parameter sets
+   Test       : Parameter file syntax in /vnmr/par300/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par300/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par400/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par400/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par500/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par500/tests/
+        Passed: 25 parameter sets
+   Test       : Parameter file syntax in /vnmr/par600/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par600/tests/
+        Passed: 24 parameter sets
+   Test       : Parameter file syntax in /vnmr/par700/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par700/tests/
+        Passed: 24 parameter sets
+   Test       : Parameter file syntax in /vnmr/par750/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par750/tests/
+        Passed: 17 parameter sets
+   Test       : Parameter file syntax in /vnmr/par800/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par800/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par900/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par900/tests/
+        Passed: 20 parameter sets
+ 
+XML syntax tests
+   Test       : Xml syntax
+        Passed: 6395 xml files
+ 
+Experiment Menu tests
+   Test       : Experiment menus
+        Passed: 341 experiment menu items
+     ***Failed: 6 experiment menu items
+failed experiment menu item: editht
+failed experiment menu item: noesyHT dps  vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: roesyHT dps  vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: noesyHT dps vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: roesyHT dps vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: Inepthxdec
+        Passed: 344 experiment go('check')
+     ***Failed: 3 experiment go('check')
+go('check') failed for PROTON dn='C13' gHMBCmeAD
+go('check') failed for PROTON gc2hmbcme
+go('check') failed for PROTON gc2h2bcme
+        Passed: 271 experiment exptime
+     ***Failed: 76 experiment exptime
+exptime failed for bashdROESY ()
+exptime failed for zTOCSY1D ()
+exptime failed for ROESY1D ()
+exptime failed for stepNOESY1D ()
+exptime failed for APT ()
+exptime failed for dqcosyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for noesyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for roesyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for dqcosyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for noesyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for roesyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for Hetcortancp2d ()
+exptime failed for Hetcorlgcp2d ()
+exptime failed for Hetcorlgcp2d_1 ()
+exptime failed for Wisetancp2d ()
+exptime failed for Exsy2d ()
+exptime failed for Mashmqc2d ()
+exptime failed for Masapt1d ()
+exptime failed for Mashsqc2d ()
+exptime failed for C7inad2d ()
+exptime failed for Spc5inad2d ()
+exptime failed for Cpinad2d ()
+exptime failed for R14inad2d ()
+exptime failed for Babainad2d ()
+exptime failed for Tancp2drad ()
+exptime failed for Tancp2dspc5 ()
+exptime failed for Pisema2d ()
+exptime failed for Sammy2d ()
+exptime failed for Pisematest1 ()
+exptime failed for Pisematest2 ()
+exptime failed for Lgcp2d ()
+exptime failed for Sc14inad2d ()
+exptime failed for Super2d ()
+exptime failed for Hetcorsamlgcp2d_1 ()
+exptime failed for Hetcorpmlgcp2d_1 ()
+exptime failed for Hetcordumbolgcp2d_1 ()
+exptime failed for Hh2dhdec ()
+exptime failed for IdHetcor ()
+exptime failed for IdInept ()
+exptime failed for Inepthxdec ()
+exptime failed for Tancpxhdec ()
+exptime failed for Tancpxhdeccpmg ()
+exptime failed for Jmasnca2d ()
+exptime failed for Jmasnco2d ()
+exptime failed for Jmascaco2d ()
+exptime failed for Jmascacoipap2d ()
+exptime failed for Jmascacosh2d ()
+exptime failed for Redor1tancp ()
+exptime failed for Redor2tancp ()
+exptime failed for Redor1onepul ()
+exptime failed for Redor2onepul ()
+exptime failed for Fsredor ()
+exptime failed for Dcptan3drad ()
+exptime failed for Dcp2tan3drad ()
+exptime failed for Dcptan3dspc5 ()
+exptime failed for Dcptan ()
+exptime failed for Decorcptan2d ()
+exptime failed for Ineptxyonepul ()
+exptime failed for Ineptxytancp ()
+exptime failed for Ineptxyrefonepul ()
+exptime failed for Ineptxyreftancp ()
+exptime failed for Trapdorycpx ()
+exptime failed for Mrev8 ()
+exptime failed for Mrev8q ()
+exptime failed for Wpmlg1d ()
+exptime failed for Wpmlg2d ()
+exptime failed for C7inadwpmlg2d ()
+exptime failed for Wdumbo1d ()
+exptime failed for Wdumbot1d ()
+exptime failed for C7inadwdumbot2d ()
+exptime failed for C7inadwdumbogen2d ()
+exptime failed for Spsmall ()
+exptime failed for Wpmlgxmx1d ()
+exptime failed for Wdumboxmx1d ()
+exptime failed for Wdumbogen1d ()
+exptime failed for Qcpmgsh1d ()
+ 
+Libraries for binaries tests
+   Test       : Program ldd test of /vnmr/bin/
+        Passed: 222 programs
+     ***Failed: 8 programs
+failed program: /vnmr/bin/addTables
+failed program: /vnmr/bin/calcFit
+failed program: /vnmr/bin/fidelityFit
+failed program: /vnmr/bin/fidelityPlots
+failed program: /vnmr/bin/kermit
+failed program: /vnmr/bin/matlabPlots
+failed program: /vnmr/bin/powerTables
+failed program: /vnmr/bin/shapeFit
+   Test       : Program ldd test of /vnmr/biopack/BioPack.dir/BP_files/bin/
+   Test       : Program ldd test of /vnmr/biopack/bin/
+        Passed: 14 programs
+   Test       : Program ldd test of /vnmr/craft/bin/
+        Passed: 4 programs
+   Test       : Program ldd test of /vnmr/dicom/bin/
+        Passed: 8 programs
+     ***Failed: 3 programs
+failed program: /vnmr/dicom/bin/echoscu
+failed program: /vnmr/dicom/bin/storescp
+failed program: /vnmr/dicom/bin/storescu
+   Test       : Program ldd test of /vnmr/openvnmrj-utils/bin/
+        Passed: 3 programs
+   Test       : Program ldd test of /vnmr/tcl/bin/
+        Passed: 13 programs
+   Test       : Program ldd test of /vnmr/user_templates/ib_initdir/math/expressions/bin/
+   Test       : Program ldd test of /vnmr/user_templates/ib_initdir/math/functions/bin/
+        Passed: 11 programs
+   Test       : Program ldd test of /vnmr/lib/
+        Passed: 27 programs
+ 
+Linux commands accessed by shell
+   Test       : Access shell commands from /vnmr/autotest/maclib/
+   Test       : Access shell commands from /vnmr/biopack/BioPack.dir/BP_files/maclib/
+   Test       : Access shell commands from /vnmr/biopack/maclib/
+   Test       : Access shell commands from /vnmr/biosolidspack/maclib/
+   Test       : Access shell commands from /vnmr/craft/maclib/
+   Test       : Access shell commands from /vnmr/gxyzshim/maclib/
+   Test       : Access shell commands from /vnmr/imaging/maclib/
+   Test       : Access shell commands from /vnmr/maclib/
+   Test       : Access shell commands from /vnmr/openvnmrj-utils/maclib/
+   Test       : Access shell commands from /vnmr/solidspack/maclib/
+   Test       : Access shell commands from /vnmr/veripulse/maclib/
+   Test       : Access shell commands from /vnmr/menujlib/
+        Passed: 112 shell commands
+     ***Failed: 7 shell commands
+command not found: pr3db
+command not found: acroread
+command not found: gedit
+command not found: /bin/gawk
+command not found: sw_vers
+command not found: xterm
+command not found: nautilus
+ 
+DSSL test
+   Test       : dssl bug for multiple arrays
+        Passed: 
+ 
+DEA test
+   Test       : DEA integration and baseline correction
+        Passed:  with secondary values
+ 
+PSG tests
+   Test       : Seqgen syntax of /vnmr/autotest/psglib/ with 18 sequences
+        Passed: 18 pulse sequences
+   Test       : Seqgen syntax of /vnmr/biopack/psglib/ with 405 sequences
+        Passed: 405 pulse sequences
+   Test       : Seqgen syntax of /vnmr/biosolidspack/psglib/ with 5 sequences
+        Passed: 5 pulse sequences
+   Test       : Seqgen syntax of /vnmr/gxyzshim/psglib/ with 1 sequences
+        Passed: 1 pulse sequences
+   Test       : Seqgen syntax of /vnmr/imaging/psglib/ with 57 sequences
+        Passed: 57 pulse sequences
+   Test       : Seqgen syntax of /vnmr/psglib/ with 206 sequences
+        Passed: 206 pulse sequences
+   Test       : Seqgen syntax of /vnmr/solidspack/psglib/ with 162 sequences
+        Passed: 162 pulse sequences
+   Test       : Seqgen syntax of /vnmr/veripulse/psglib/ with 1 sequences
+        Passed: 1 pulse sequences
+   Test       : psggen
+        Passed: psggen
+   Test       : fixpsg
+        Passed: fixpsg

--- a/logs/gold_vjqa/vjqa-ubuntu18.txt
+++ b/logs/gold_vjqa/vjqa-ubuntu18.txt
@@ -1,0 +1,361 @@
+ 
+ 
+Start QA testing
+Mar 27 2019 at 19:24:39
+ 
+
+OpenVnmrJ VERSION 1.1 REVISION A
+March 27, 2019
+propulse
+
+OS:
+Ubuntu 18.04.1 LTS
+ 
+Installation tests
+   Test       : VnmrJ installation
+     ***Failed: VnmrJ installation
+ 
+Macro syntax tests
+   Test       : Macro syntax of /vnmr/autotest/maclib/
+        Passed: 309 macros
+   Test       : Macro syntax of /vnmr/biopack/BioPack.dir/BP_files/maclib/
+   Test       : Macro syntax of /vnmr/biopack/maclib/
+        Passed: 1052 macros
+   Test       : Macro syntax of /vnmr/biosolidspack/maclib/
+        Passed: 240 macros
+   Test       : Macro syntax of /vnmr/craft/maclib/
+        Passed: 193 macros
+   Test       : Macro syntax of /vnmr/gxyzshim/maclib/
+        Passed: 48 macros
+   Test       : Macro syntax of /vnmr/imaging/maclib/
+        Passed: 459 macros
+   Test       : Macro syntax of /vnmr/maclib/
+        Passed: 2363 macros
+   Test       : Macro syntax of /vnmr/openvnmrj-utils/maclib/
+        Passed: 2 macros
+   Test       : Macro syntax of /vnmr/solidspack/maclib/
+        Passed: 544 macros
+   Test       : Macro syntax of /vnmr/veripulse/maclib/
+        Passed: 168 macros
+   Test       : Tested a total of 5378 macros
+ 
+Parfile rtp tests
+   Test       : Parameter file syntax in /vnmr/biopack/parlib/
+        Passed: 367 parameter sets
+   Test       : Parameter file syntax in /vnmr/biosolidspack/parlib/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-10_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-11_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-12_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-13_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-14_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-15_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-1_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-2_04Oct12_01/dirinfo/parlib/
+        Passed: 2 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-3_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-4_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-5_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-6_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-7_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-8_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-9_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-10_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-11_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-12_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-13_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-14_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-15_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-1_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-2_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-3_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-4_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-7_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-8_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-9_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-10_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-11_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-14_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-15_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-16_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-1_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-2_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-3_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-4_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-5_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-6_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-7_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-8_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-9_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/gxyzshim/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/imaging/ATP/parlib/
+        Passed: 13 parameter sets
+   Test       : Parameter file syntax in /vnmr/imaging/parlib/
+        Passed: 79 parameter sets
+   Test       : Parameter file syntax in /vnmr/parlib/
+        Passed: 242 parameter sets
+   Test       : Parameter file syntax in /vnmr/solidspack/parlib/
+        Passed: 162 parameter sets
+   Test       : Parameter file syntax in /vnmr/veripulse/parlib/
+        Passed: 10 parameter sets
+   Test       : Parameter file syntax in /vnmr/par200/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par200/tests/
+        Passed: 21 parameter sets
+   Test       : Parameter file syntax in /vnmr/par300/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par300/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par400/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par400/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par500/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par500/tests/
+        Passed: 25 parameter sets
+   Test       : Parameter file syntax in /vnmr/par600/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par600/tests/
+        Passed: 24 parameter sets
+   Test       : Parameter file syntax in /vnmr/par700/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par700/tests/
+        Passed: 24 parameter sets
+   Test       : Parameter file syntax in /vnmr/par750/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par750/tests/
+        Passed: 17 parameter sets
+   Test       : Parameter file syntax in /vnmr/par800/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par800/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par900/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par900/tests/
+        Passed: 20 parameter sets
+ 
+XML syntax tests
+   Test       : Xml syntax
+        Passed: 6395 xml files
+ 
+Experiment Menu tests
+   Test       : Experiment menus
+        Passed: 341 experiment menu items
+     ***Failed: 6 experiment menu items
+failed experiment menu item: editht
+failed experiment menu item: noesyHT dps  vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: roesyHT dps  vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: noesyHT dps vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: roesyHT dps vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: Inepthxdec
+        Passed: 344 experiment go('check')
+     ***Failed: 3 experiment go('check')
+go('check') failed for PROTON dn='C13' gHMBCmeAD
+go('check') failed for PROTON gc2hmbcme
+go('check') failed for PROTON gc2h2bcme
+        Passed: 271 experiment exptime
+     ***Failed: 76 experiment exptime
+exptime failed for bashdROESY ()
+exptime failed for zTOCSY1D ()
+exptime failed for ROESY1D ()
+exptime failed for stepNOESY1D ()
+exptime failed for APT ()
+exptime failed for dqcosyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for noesyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for roesyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for dqcosyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for noesyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for roesyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for Hetcortancp2d ()
+exptime failed for Hetcorlgcp2d ()
+exptime failed for Hetcorlgcp2d_1 ()
+exptime failed for Wisetancp2d ()
+exptime failed for Exsy2d ()
+exptime failed for Mashmqc2d ()
+exptime failed for Masapt1d ()
+exptime failed for Mashsqc2d ()
+exptime failed for C7inad2d ()
+exptime failed for Spc5inad2d ()
+exptime failed for Cpinad2d ()
+exptime failed for R14inad2d ()
+exptime failed for Babainad2d ()
+exptime failed for Tancp2drad ()
+exptime failed for Tancp2dspc5 ()
+exptime failed for Pisema2d ()
+exptime failed for Sammy2d ()
+exptime failed for Pisematest1 ()
+exptime failed for Pisematest2 ()
+exptime failed for Lgcp2d ()
+exptime failed for Sc14inad2d ()
+exptime failed for Super2d ()
+exptime failed for Hetcorsamlgcp2d_1 ()
+exptime failed for Hetcorpmlgcp2d_1 ()
+exptime failed for Hetcordumbolgcp2d_1 ()
+exptime failed for Hh2dhdec ()
+exptime failed for IdHetcor ()
+exptime failed for IdInept ()
+exptime failed for Inepthxdec ()
+exptime failed for Tancpxhdec ()
+exptime failed for Tancpxhdeccpmg ()
+exptime failed for Jmasnca2d ()
+exptime failed for Jmasnco2d ()
+exptime failed for Jmascaco2d ()
+exptime failed for Jmascacoipap2d ()
+exptime failed for Jmascacosh2d ()
+exptime failed for Redor1tancp ()
+exptime failed for Redor2tancp ()
+exptime failed for Redor1onepul ()
+exptime failed for Redor2onepul ()
+exptime failed for Fsredor ()
+exptime failed for Dcptan3drad ()
+exptime failed for Dcp2tan3drad ()
+exptime failed for Dcptan3dspc5 ()
+exptime failed for Dcptan ()
+exptime failed for Decorcptan2d ()
+exptime failed for Ineptxyonepul ()
+exptime failed for Ineptxytancp ()
+exptime failed for Ineptxyrefonepul ()
+exptime failed for Ineptxyreftancp ()
+exptime failed for Trapdorycpx ()
+exptime failed for Mrev8 ()
+exptime failed for Mrev8q ()
+exptime failed for Wpmlg1d ()
+exptime failed for Wpmlg2d ()
+exptime failed for C7inadwpmlg2d ()
+exptime failed for Wdumbo1d ()
+exptime failed for Wdumbot1d ()
+exptime failed for C7inadwdumbot2d ()
+exptime failed for C7inadwdumbogen2d ()
+exptime failed for Spsmall ()
+exptime failed for Wpmlgxmx1d ()
+exptime failed for Wdumboxmx1d ()
+exptime failed for Wdumbogen1d ()
+exptime failed for Qcpmgsh1d ()
+ 
+Libraries for binaries tests
+   Test       : Program ldd test of /vnmr/bin/
+        Passed: 211 programs
+     ***Failed: 8 programs
+failed program: /vnmr/bin/addTables
+failed program: /vnmr/bin/calcFit
+failed program: /vnmr/bin/fidelityFit
+failed program: /vnmr/bin/fidelityPlots
+failed program: /vnmr/bin/kermit
+failed program: /vnmr/bin/matlabPlots
+failed program: /vnmr/bin/powerTables
+failed program: /vnmr/bin/shapeFit
+   Test       : Program ldd test of /vnmr/biopack/BioPack.dir/BP_files/bin/
+   Test       : Program ldd test of /vnmr/biopack/bin/
+        Passed: 14 programs
+   Test       : Program ldd test of /vnmr/craft/bin/
+        Passed: 4 programs
+   Test       : Program ldd test of /vnmr/dicom/bin/
+        Passed: 8 programs
+     ***Failed: 3 programs
+failed program: /vnmr/dicom/bin/echoscu
+failed program: /vnmr/dicom/bin/storescp
+failed program: /vnmr/dicom/bin/storescu
+   Test       : Program ldd test of /vnmr/openvnmrj-utils/bin/
+        Passed: 3 programs
+   Test       : Program ldd test of /vnmr/tcl/bin/
+        Passed: 13 programs
+   Test       : Program ldd test of /vnmr/user_templates/ib_initdir/math/expressions/bin/
+   Test       : Program ldd test of /vnmr/user_templates/ib_initdir/math/functions/bin/
+        Passed: 11 programs
+   Test       : Program ldd test of /vnmr/lib/
+        Passed: 27 programs
+ 
+Linux commands accessed by shell
+   Test       : Access shell commands from /vnmr/autotest/maclib/
+   Test       : Access shell commands from /vnmr/biopack/BioPack.dir/BP_files/maclib/
+   Test       : Access shell commands from /vnmr/biopack/maclib/
+   Test       : Access shell commands from /vnmr/biosolidspack/maclib/
+   Test       : Access shell commands from /vnmr/craft/maclib/
+   Test       : Access shell commands from /vnmr/gxyzshim/maclib/
+   Test       : Access shell commands from /vnmr/imaging/maclib/
+   Test       : Access shell commands from /vnmr/maclib/
+   Test       : Access shell commands from /vnmr/openvnmrj-utils/maclib/
+   Test       : Access shell commands from /vnmr/solidspack/maclib/
+   Test       : Access shell commands from /vnmr/veripulse/maclib/
+   Test       : Access shell commands from /vnmr/menujlib/
+        Passed: 113 shell commands
+     ***Failed: 6 shell commands
+command not found: pr3db
+command not found: acroread
+command not found: /bin/gawk
+command not found: sw_vers
+command not found: xterm
+command not found: nautilus
+ 
+DSSL test
+   Test       : dssl bug for multiple arrays
+        Passed: 
+ 
+DEA test
+   Test       : DEA integration and baseline correction
+     ***Failed: Dea test: 98.03 +/-0.34% (7 of 8 integrals)
+ 
+PSG tests
+   Test       : Seqgen syntax of /vnmr/autotest/psglib/ with 18 sequences
+        Passed: 18 pulse sequences
+   Test       : Seqgen syntax of /vnmr/biopack/psglib/ with 405 sequences
+        Passed: 405 pulse sequences
+   Test       : Seqgen syntax of /vnmr/biosolidspack/psglib/ with 5 sequences
+        Passed: 5 pulse sequences
+   Test       : Seqgen syntax of /vnmr/gxyzshim/psglib/ with 1 sequences
+        Passed: 1 pulse sequences
+   Test       : Seqgen syntax of /vnmr/imaging/psglib/ with 57 sequences
+        Passed: 57 pulse sequences
+   Test       : Seqgen syntax of /vnmr/psglib/ with 206 sequences
+        Passed: 206 pulse sequences
+   Test       : Seqgen syntax of /vnmr/solidspack/psglib/ with 162 sequences
+        Passed: 162 pulse sequences
+   Test       : Seqgen syntax of /vnmr/veripulse/psglib/ with 1 sequences
+        Passed: 1 pulse sequences
+   Test       : psggen
+        Passed: psggen
+   Test       : fixpsg
+        Passed: fixpsg

--- a/vms/box_defs/centos6/Vagrantfile
+++ b/vms/box_defs/centos6/Vagrantfile
@@ -8,6 +8,9 @@
 #
 # For more information, see the LICENSE file.
 #
+def gui?; !ENV.fetch('OVJ_VM_GUI', '').empty?; end
+def ncpu; Integer(ENV.fetch('OVJ_VM_NCPU', '1')); end
+def mem; Integer(ENV.fetch('OVJ_VM_MEM', "%d" % (ncpu * 1024))); end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "bento/centos-6.10"
@@ -17,10 +20,10 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false # only needed for vagrant 1.8.5 #7610
   config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.provider "virtualbox" do |vb|
-    #vb.gui = true
     vb.linked_clone = true
-    vb.memory = "8192"
-    vb.cpus = 4
+    vb.gui = gui?
+    vb.memory = mem
+    vb.cpus = ncpu
     vb.customize "pre-boot", ["storageattach", :id,
                               "--storagectl", "IDE Controller",
                               "--port", "1",
@@ -29,6 +32,7 @@ Vagrant.configure("2") do |config|
                               "--medium", "emptydrive",
                              ]
   end
+  config.vm.post_up_message = "VM started with #{ncpu} cpus, #{mem} MB memory, and gui=#{gui?}"
   config.vm.provision "shell", inline: <<-SHELL
     set -e
     yum install -y epel-release
@@ -36,7 +40,7 @@ Vagrant.configure("2") do |config|
 
     # these are needed to build
     yum install -y git scons zip unzip gcc-gfortran gcc-c++ mesa-libGL-devel \
-        mesa-libGLU-devel gsl-devel libtiff-devel
+        mesa-libGLU-devel gsl-devel
     yum install -y glibc-devel.i686 libstdc++.i686 libX11-devel.i686 \
         libXt-devel.i686 openmotif-devel.i686
 

--- a/vms/box_defs/centos7/Vagrantfile
+++ b/vms/box_defs/centos7/Vagrantfile
@@ -8,6 +8,9 @@
 #
 # For more information, see the LICENSE file.
 #
+def gui?; !ENV.fetch('OVJ_VM_GUI', '').empty?; end
+def ncpu; Integer(ENV.fetch('OVJ_VM_NCPU', '1')); end
+def mem; Integer(ENV.fetch('OVJ_VM_MEM', "%d" % (ncpu * 1024))); end
 
 Vagrant.configure("2") do |config|
   #config.vm.box = "centos/7"
@@ -16,12 +19,12 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false # only needed for vagrant 1.8.5 #7610
   config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.provider "virtualbox" do |vb|
-    # Display the VirtualBox GUI when booting the machine
-    #vb.gui = true
     vb.linked_clone = true
-    vb.memory = "8192"
-    vb.cpus = 4
+    vb.gui = gui?
+    vb.memory = mem
+    vb.cpus = ncpu
   end
+  config.vm.post_up_message = "VM started with #{ncpu} cpus, #{mem} MB memory, and gui=#{gui?}"
   config.vm.provision "shell", inline: <<-SHELL
     set -e
     yum install -y epel-release
@@ -29,7 +32,7 @@ Vagrant.configure("2") do |config|
 
     # these are needed to build
     yum install -y git scons zip unzip gcc-gfortran gcc-c++ gsl-devel \
-        mesa-libGL-devel mesa-libGLU-devel libtiff-devel
+        mesa-libGL-devel mesa-libGLU-devel
     yum install -y glibc-devel.i686 libstdc++.i686 libX11-devel.i686 \
         libXt-devel.i686 motif-devel.i686
 

--- a/vms/box_defs/macos10.10/Vagrantfile
+++ b/vms/box_defs/macos10.10/Vagrantfile
@@ -8,18 +8,20 @@
 #
 # For more information, see the LICENSE file.
 #
+def gui?; !ENV.fetch('OVJ_VM_GUI', '').empty?; end
+def ncpu; Integer(ENV.fetch('OVJ_VM_NCPU', '1')); end
+def mem; Integer(ENV.fetch('OVJ_VM_MEM', "%d" % (ncpu * 1024))); end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "AndrewDryga/vagrant-box-osx"
   config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.provider "virtualbox" do |vb|
-    # Display the VirtualBox GUI when booting the machine
-    #vb.gui = true
-    # Customize the amount of memory on the VM:
     vb.linked_clone = true
-    vb.memory = "8192"
-    vb.cpus = 4
+    vb.gui = gui?
+    vb.memory = mem
+    vb.cpus = ncpu
   end
+  config.vm.post_up_message = "VM started with #{ncpu} cpus, #{mem} MB memory, and gui=#{gui?}"
 
   # brew runs as a user
   config.vm.provision "shell", privileged: false, inline: <<-SHELL

--- a/vms/box_defs/ubuntu14/Vagrantfile
+++ b/vms/box_defs/ubuntu14/Vagrantfile
@@ -8,6 +8,9 @@
 #
 # For more information, see the LICENSE file.
 #
+def gui?; !ENV.fetch('OVJ_VM_GUI', '').empty?; end
+def ncpu; Integer(ENV.fetch('OVJ_VM_NCPU', '1')); end
+def mem; Integer(ENV.fetch('OVJ_VM_MEM', "%d" % (ncpu * 1024))); end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
@@ -15,11 +18,12 @@ Vagrant.configure("2") do |config|
   #config.vm.box = "chad-thompson/ubuntu-trusty64-gui"
   config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.provider "virtualbox" do |vb|
-    #vb.gui = true
     vb.linked_clone = true
-    vb.memory = "8192"
-    vb.cpus = 4
+    vb.gui = gui?
+    vb.memory = mem
+    vb.cpus = ncpu
   end
+  config.vm.post_up_message = "VM started with #{ncpu} cpus, #{mem} MB memory, and gui=#{gui?}"
   config.vm.provision "shell", inline: <<-SHELL
     export DEBIAN_FRONTEND=noninteractive
     set -e

--- a/vms/box_defs/ubuntu16/Vagrantfile
+++ b/vms/box_defs/ubuntu16/Vagrantfile
@@ -8,6 +8,9 @@
 #
 # For more information, see the LICENSE file.
 #
+def gui?; !ENV.fetch('OVJ_VM_GUI', '').empty?; end
+def ncpu; Integer(ENV.fetch('OVJ_VM_NCPU', '1')); end
+def mem; Integer(ENV.fetch('OVJ_VM_MEM', "%d" % (ncpu * 1024))); end
 
 Vagrant.configure("2") do |config|
   #config.vm.box = "ubuntu/xenial64"
@@ -15,10 +18,12 @@ Vagrant.configure("2") do |config|
   config.vm.box = "bento/ubuntu-16.04"
   config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.provider "virtualbox" do |vb|
-    #vb.gui = true
-    vb.cpus = 3
-    vb.memory = "%d" % (1024 * 3)
+    vb.linked_clone = true
+    vb.gui = gui?
+    vb.memory = mem
+    vb.cpus = ncpu
   end
+  config.vm.post_up_message = "VM started with #{ncpu} cpus, #{mem} MB memory, and gui=#{gui?}"
   config.vm.provision "shell", inline: <<-SHELL
     export DEBIAN_FRONTEND=noninteractive
     set -e
@@ -35,10 +40,12 @@ Vagrant.configure("2") do |config|
     # these are needed to install
     #apt-get install -y openjdk-8-jre
     apt-get install -y csh expect bc rsh-server tftpd mutt sharutils \
-            gnome-power-manager k3b kdiff3 rarpd
+            gnome-power-manager gnome-terminal k3b kdiff3 rarpd \
+            ghostscript imagemagick postgresql dos2unix zip cups \
+            gnuplot enscript
     #debconf-set-selections <<< "postfix postfix/mailname string your.hostname.com"
     #debconf-set-selections <<< "postfix postfix/main_mailer_type string 'Internet Site'"
-    apt-get install -y ghostscript imagemagick postgresql sendmail-cf
+    apt-get install -y sendmail-cf
 
     chmod a+rw /var/run/postgresql
 

--- a/vms/centos6/Vagrantfile
+++ b/vms/centos6/Vagrantfile
@@ -8,15 +8,9 @@
 #
 # For more information, see the LICENSE file.
 #
-
-# Returns true if `VMGUI` environment variable is set to a non-empty value.
-# Defaults to false
-def gui_enabled?
-  !ENV.fetch('VMGUI', '').empty?
-end
-def ncpu
-  Integer(ENV.fetch('VMNCPU', '1'))
-end
+def gui?; !ENV.fetch('OVJ_VM_GUI', '').empty?; end
+def ncpu; Integer(ENV.fetch('OVJ_VM_NCPU', '1')); end
+def mem; Integer(ENV.fetch('OVJ_VM_MEM', "%d" % (ncpu * 1024))); end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "OpenVnmrJ/centos6"
@@ -24,11 +18,14 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false # only needed for vagrant 1.8.5 #7610
   config.vbguest.auto_update = false
   config.vm.provider "virtualbox" do |vb|
-    vb.gui = gui_enabled?
     vb.linked_clone = true
-    vb.memory = "4096"
+    vb.gui = gui?
+    vb.memory = mem
+    vb.cpus = ncpu
+    #vb.memory = "4096"
     #vb.cpus = 2
   end
+  config.vm.post_up_message = "VM started with #{ncpu} cpus, #{mem} MB memory, and gui=#{gui?}"
   config.vm.provision "shell", inline: <<-SHELL
     echo "do nothing"
   SHELL

--- a/vms/centos7/Vagrantfile
+++ b/vms/centos7/Vagrantfile
@@ -8,15 +8,9 @@
 #
 # For more information, see the LICENSE file.
 #
-
-# Returns true if `VMGUI` environment variable is set to a non-empty value.
-# Defaults to false
-def gui_enabled?
-  !ENV.fetch('VMGUI', '').empty?
-end
-def ncpu
-  Integer(ENV.fetch('VMNCPU', '1'))
-end
+def gui?; !ENV.fetch('OVJ_VM_GUI', '').empty?; end
+def ncpu; Integer(ENV.fetch('OVJ_VM_NCPU', '1')); end
+def mem; Integer(ENV.fetch('OVJ_VM_MEM', "%d" % (ncpu * 1024))); end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "OpenVnmrJ/centos7"
@@ -24,13 +18,12 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false # only needed for vagrant 1.8.5 #7610
   config.vbguest.auto_update = false
   config.vm.provider "virtualbox" do |vb|
-    # Display the VirtualBox GUI when booting the machine
-    #vb.gui = true
-    vb.gui = gui_enabled?
     vb.linked_clone = true
-    vb.memory = "%d" % (ncpu * 1024)
+    vb.gui = gui?
+    vb.memory = mem
     vb.cpus = ncpu
   end
+  config.vm.post_up_message = "VM started with #{ncpu} cpus, #{mem} MB memory, and gui=#{gui?}"
   config.vm.provision "shell", inline: <<-SHELL
     echo "do nothing"
   SHELL

--- a/vms/fedora29/Vagrantfile
+++ b/vms/fedora29/Vagrantfile
@@ -1,0 +1,59 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+# Copyright (C) 2016  Michael Tesch
+#
+# You may distribute under the terms of either the GNU General Public
+# License or the Apache License, as specified in the LICENSE file.
+#
+# For more information, see the LICENSE file.
+#
+def gui?; !ENV.fetch('OVJ_VM_GUI', '').empty?; end
+def ncpu; Integer(ENV.fetch('OVJ_VM_NCPU', '1')); end
+def mem; Integer(ENV.fetch('OVJ_VM_MEM', "%d" % (ncpu * 1024))); end
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/fedora-29"
+  config.vm.box_version = "201812.27.0"
+  #config.ssh.insert_key = false # only needed for vagrant 1.8.5 #7610
+  #config.vbguest.auto_update = false
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+  config.vm.provider "virtualbox" do |vb|
+    vb.linked_clone = true
+    vb.gui = gui?
+    vb.memory = mem
+    vb.cpus = ncpu
+  end
+  config.vm.post_up_message = "VM started with #{ncpu} cpus, #{mem} MB memory, and gui=#{gui?}"
+  config.vm.provision "shell", inline: <<-SHELL
+    set -ex
+    dnf update -y
+
+    # these are needed to build
+    dnf install -y git scons zip unzip gcc-gfortran gcc-c++ \
+        mesa-libGL-devel mesa-libGLU-devel gsl-devel libnsl \
+        kernel-devel glibc-devel \
+        glibc-devel.i686 libstdc++.i686 libX11-devel.i686 \
+        libXt-devel.i686 motif-devel.i686 libtirpc-devel.i686
+
+    # these are needed to install
+    dnf -y group install "Basic Desktop"
+
+    dnf install -y gdb libtool automake autoconf rsh-server \
+        xinetd tftp-server strace tcsh  \
+        sendmail-cf k3b ghostscript ImageMagick rsh
+
+    dnf install -y libXtst-devel.i686 libXext-devel.i686 libXi.i686 \
+        libstdc++-devel.i686 ncurses-libs.i686 ncurses-devel.i686 \
+        mesa-libGL-devel.i686 atk.i686 gtk2.i686 mesa-libGL.i686 \
+        mesa-libGLU.i686 libidn.i686 libxml2.i686 libXaw.i686 libXpm.i686
+
+    systemctl set-default graphical.target
+    systemctl start graphical.target
+
+    dnf clean all
+    # disable SELinux
+    setenforce 0
+    sed -i 's/SELINUX=\(enforcing\|permissive\)/SELINUX=disabled/g' /etc/selinux/config
+  SHELL
+end

--- a/vms/macos10.10/Vagrantfile
+++ b/vms/macos10.10/Vagrantfile
@@ -8,12 +8,9 @@
 #
 # For more information, see the LICENSE file.
 #
-
-# Returns true if `VMGUI` environment variable is set to a non-empty value.
-# Defaults to false
-def gui_enabled?
-  !ENV.fetch('VMGUI', '').empty?
-end
+def gui?; !ENV.fetch('OVJ_VM_GUI', '').empty?; end
+def ncpu; Integer(ENV.fetch('OVJ_VM_NCPU', '1')); end
+def mem; Integer(ENV.fetch('OVJ_VM_MEM', "%d" % (ncpu * 1024))); end
 
 Vagrant.configure("2") do |config|
   #config.vm.box = "AndrewDryga/vagrant-box-osx"
@@ -23,12 +20,10 @@ Vagrant.configure("2") do |config|
 
   config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.provider "virtualbox" do |vb|
-    # Display the VirtualBox GUI when booting the machine
-    vb.gui = gui_enabled?
-    # the mac disk images are YUUUGE
     vb.linked_clone = true
-    # Customize the amount of memory on the VM:
-    #vb.memory = "4096"
+    vb.gui = gui?
+    vb.memory = mem
+    vb.cpus = ncpu
 
     unless File.exist?('tmp2.vmdk')
       vb.customize ['createhd', '--filename', 'tmp2.vmdk', '--size', 20*1024, '--format', 'vmdk' ]
@@ -42,6 +37,7 @@ Vagrant.configure("2") do |config|
                   '--medium', 'tmp2.vmdk']
 
   end
+  config.vm.post_up_message = "VM started with #{ncpu} cpus, #{mem} MB memory, and gui=#{gui?}"
 
   # create a case-sensitive filesystem on the vmdk from above
   config.vm.provision "shell", inline: <<-SHELL
@@ -53,7 +49,8 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     set -e
     brew update
-    brew install scons postgres
+    brew install scons || brew upgrade scons
+    brew install postgres || brew upgrade postgres
   SHELL
 
 end

--- a/vms/mint19/Vagrantfile
+++ b/vms/mint19/Vagrantfile
@@ -1,0 +1,63 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+# Copyright (C) 2018  Michael Tesch
+#
+# This file is a part of the OpenVnmrJ project.  You may distribute it
+# under the terms of either the GNU General Public License or the
+# Apache 2.0 License, as specified in the LICENSE file.
+#
+# For more information, see the OpenVnmrJ LICENSE file.
+#
+def gui?; !ENV.fetch('OVJ_VM_GUI', '').empty?; end
+def ncpu; Integer(ENV.fetch('OVJ_VM_NCPU', '1')); end
+def mem; Integer(ENV.fetch('OVJ_VM_MEM', "%d" % (ncpu * 1024))); end
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ajxb/mint-19.0"
+  config.vm.box_version = "1.0.2"
+  #config.vm.box = "mrlesmithjr/linuxmint19-desktop"
+  #config.vm.synced_folder '.', '/vagrant', disabled: true
+  config.vm.provider "virtualbox" do |vb|
+    vb.gui = gui?
+    vb.memory = mem
+    vb.cpus = ncpu
+    if (/darwin/ =~ RUBY_PLATFORM) != nil
+      vb.default_nic_type = "virtio"
+    end
+  end
+  config.vm.network "private_network", ip: "192.168.50.4", nic_type: "virtio"
+  config.vm.post_up_message = "VM started with #{ncpu} cpus, #{mem} MB memory, and gui=#{gui?}"
+  config.vm.provision "shell", inline: <<-SHELL
+    export DEBIAN_FRONTEND=noninteractive
+    set -e
+    dpkg --add-architecture i386
+    apt-get -qq update
+    apt-get -qq -y dist-upgrade
+
+    # these are needed to build
+    apt-get install -y git scons g++ gfortran gdm3 gnome-session \
+      lib32stdc++-7-dev libc6-dev-i386 libglu1-mesa-dev
+
+    # these are needed to install
+    #apt-get install -y openjdk-8-jre
+    apt-get install -y csh expect bc rsh-server tftpd \
+      mutt sharutils gnome-power-manager k3b kdiff3 rarpd \
+      ghostscript imagemagick postgresql sendmail-cf \
+      gedit dos2unix zip cups gnuplot gnome-terminal enscript
+    #debconf-set-selections <<< "postfix postfix/mailname string your.hostname.com"
+    #debconf-set-selections <<< "postfix postfix/main_mailer_type string 'Internet Site'"
+    chmod a+rw /var/run/postgresql
+
+    # these are needed to build
+    # apt-get uninstalls these if an amd64 version is installed for something else >:(
+    # so install them last...
+    apt-get install -y libmotif-dev:i386 libx11-dev:i386 libxt-dev:i386 libxft-dev:i386
+
+    echo "dash dash/sh boolean false" | debconf-set-selections
+    dpkg-reconfigure dash
+
+    # dpkg-reconfigure gdm
+    # echo "127.0.0.1 $(hostname)" >> /etc/hosts
+  SHELL
+end

--- a/vms/ubuntu14/Vagrantfile
+++ b/vms/ubuntu14/Vagrantfile
@@ -8,27 +8,21 @@
 #
 # For more information, see the LICENSE file.
 #
-
-# Returns true if `VMGUI` environment variable is set to a non-empty value.
-# Defaults to false
-def gui_enabled?
-  !ENV.fetch('VMGUI', '').empty?
-end
-def ncpu
-  Integer(ENV.fetch('VMNCPU', '1'))
-end
+def gui?; !ENV.fetch('OVJ_VM_GUI', '').empty?; end
+def ncpu; Integer(ENV.fetch('OVJ_VM_NCPU', '1')); end
+def mem; Integer(ENV.fetch('OVJ_VM_MEM', "%d" % (ncpu * 1024))); end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "OpenVnmrJ/ubuntu14"
   # only update vbguest on the box_defs/ boxes
   config.vbguest.auto_update = false
   config.vm.provider "virtualbox" do |vb|
-    # Display the VirtualBox GUI when booting the machine
-    vb.gui = gui_enabled?
     vb.linked_clone = true
-    vb.memory = "%d" % (ncpu * 1024)
+    vb.gui = gui?
+    vb.memory = mem
     vb.cpus = ncpu
   end
+  config.vm.post_up_message = "VM started with #{ncpu} cpus, #{mem} MB memory, and gui=#{gui?}"
   config.vm.provision "shell", inline: <<-SHELL
     set -e
     echo "dash dash/sh boolean false" | debconf-set-selections

--- a/vms/ubuntu16/Vagrantfile
+++ b/vms/ubuntu16/Vagrantfile
@@ -8,27 +8,21 @@
 #
 # For more information, see the LICENSE file.
 #
-
-# Returns true if `VMGUI` environment variable is set to a non-empty value.
-# Defaults to false
-def gui_enabled?
-  !ENV.fetch('VMGUI', '').empty?
-end
-def ncpu
-  Integer(ENV.fetch('VMNCPU', '1'))
-end
+def gui?; !ENV.fetch('OVJ_VM_GUI', '').empty?; end
+def ncpu; Integer(ENV.fetch('OVJ_VM_NCPU', '1')); end
+def mem; Integer(ENV.fetch('OVJ_VM_MEM', "%d" % (ncpu * 1024))); end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "OpenVnmrJ/ubuntu16"
   # only update vbguest on the box_defs/ boxes
   config.vbguest.auto_update = false
   config.vm.provider "virtualbox" do |vb|
-    # Display the VirtualBox GUI when booting the machine
-    vb.gui = gui_enabled?
     vb.linked_clone = true
-    vb.memory = "%d" % (ncpu * 1024)
+    vb.gui = gui?
+    vb.memory = mem
     vb.cpus = ncpu
   end
+  config.vm.post_up_message = "VM started with #{ncpu} cpus, #{mem} MB memory, and gui=#{gui?}"
   config.vm.provision "shell", inline: <<-SHELL
     set -e
     echo "do nothing"

--- a/vms/ubuntu18/Vagrantfile
+++ b/vms/ubuntu18/Vagrantfile
@@ -9,31 +9,27 @@
 #
 # For more information, see the OpenVnmrJ LICENSE file.
 #
-
-# Returns true if `VMGUI` environment variable is set to a non-empty
-# value.  Defaults to false
-def gui_enabled?
-  !ENV.fetch('VMGUI', '').empty?
-end
-def ncpu
-  Integer(ENV.fetch('VMNCPU', '1'))
-end
+def gui?; !ENV.fetch('OVJ_VM_GUI', '').empty?; end
+def ncpu; Integer(ENV.fetch('OVJ_VM_NCPU', '1')); end
+def mem; Integer(ENV.fetch('OVJ_VM_MEM', "%d" % (ncpu * 1024))); end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "bento/ubuntu-18.04"
+  config.vm.box_version = "201812.27.0"
   config.vm.synced_folder '.', '/vagrant', disabled: true
+  config.vm.post_up_message = "VM started with #{ncpu} cpus, #{mem} MB memory, and gui=#{gui?}"
   config.vm.provider "virtualbox" do |vb|
+    vb.gui = gui?
+    vb.memory = mem
     vb.cpus = ncpu
-    vb.memory = "%d" % (ncpu * 1024)
-    # Display the VirtualBox GUI when booting the machine?
-    vb.gui = gui_enabled?
   end
   config.vm.provision "shell", inline: <<-SHELL
     export DEBIAN_FRONTEND=noninteractive
-    set -e
+    set -ex
     dpkg --add-architecture i386
-    apt-get -qq update
-    apt-get -qq -y dist-upgrade
+    apt-get -qq -y update
+    #apt-get -qq -y dist-upgrade
+    #do-release-upgrade
 
     # these are needed to build
     apt-get install -y git scons g++ gfortran gdm3 gnome-session \
@@ -52,7 +48,8 @@ Vagrant.configure("2") do |config|
     # these are needed to build
     # apt-get uninstalls these if an amd64 version is installed for something else >:(
     # so install them last...
-    apt-get install -y libmotif-dev:i386 libx11-dev:i386 libxt-dev:i386 libxft-dev:i386
+    apt-get install -y libmotif-dev:i386 libx11-dev:i386 libxt-dev:i386 \
+            libxft-dev:i386
 
     echo "dash dash/sh boolean false" | debconf-set-selections
     dpkg-reconfigure dash


### PR DESCRIPTION
- on macos the admin user isnt vnmr1, rather the current user, so allow that.
- added reference "gold" vjqa files for different OSs to track support state.
- updated build_vm.sh to print a summary at the end of a (potentially very long) run.
- updated vjqa "gold" references to reflect current builds
- added mint19 and fedora28 Vagrantfiles