### PR TITLE
Mac ID now determined from OpenVnmrJ files

### DIFF
--- a/bin/buildovj
+++ b/bin/buildovj
@@ -31,7 +31,6 @@
 #  doGitClone=no      to leave the current repo alone
 #  mail_list      addresses to email status of the build
 #  gitURL         URL for git repo.
-#  ovjAppName     used by mac version to name /Applications/ovjAppName
 #  ovjConsole     flag to tell whether to include console software
 #  sconsJoption   helps speed up the process. Typical value is #CPUs+1
 #
@@ -65,7 +64,6 @@ dvdBuildName1=dvdimageOVJ
 dvdBuildName2=dvdimageOVJMI
 dvdCopyName1=OVJ_$shortDate
 dvdCopyName2=OVJ_MI_$shortDate
-ovjAppName=OpenVnmrJ_1.1.app
 if [ "$(uname -s)" = "Darwin" ]; then
   nprocs=$(sysctl -n hw.ncpu)
 elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
@@ -110,7 +108,6 @@ ovjConsole=yes  # include console software
 # buildOVJ=no
 # buildOVJMI=no
 # ovjConsole=no
-# ovjAppName=OpenVnmrJ.app
 # sconsJoption=5
 
 date=`date +%F_%T`
@@ -120,6 +117,6 @@ then
 fi
 ovjLogFile="${ovjBuildDir}/logs/makeovj.$date"
 cd "${ovjBuildDir}"
-export ovjBuildDir workspacedir OVJ_TOOLS dvdCopyDir1 dvdCopyDir2 dvdBuildName1 dvdBuildName2 dvdCopyName1 dvdCopyName2 ovjLogFile doScons doGitClone mail_list gitURL gitSSH gitBranch ovjAppName buildOVJ buildOVJMI ovjConsole sconsJoption osxflags
+export ovjBuildDir workspacedir OVJ_TOOLS dvdCopyDir1 dvdCopyDir2 dvdBuildName1 dvdBuildName2 dvdCopyName1 dvdCopyName2 ovjLogFile doScons doGitClone mail_list gitURL gitSSH gitBranch buildOVJ buildOVJMI ovjConsole sconsJoption osxflags
 "${ovjBuildDir}/bin/makeovj" > "${ovjLogFile}" 2>&1
 


### PR DESCRIPTION
the ovjAppName used to be passed by the ovjTools bin/buildovj script
It is now determined in the OpenVnmrJ src/scripts/ovjmacout script