### PR TITLE
Minimum MacOS build is now High Sierra rather than Mojave

### DIFF
--- a/bin/buildovj
+++ b/bin/buildovj
@@ -50,8 +50,8 @@ if [ "$(uname -s)" = "Darwin" ]; then
       echo "Case insensitive file system. Watch out for biosolidspack experiments"
     fi
   fi
-  export osxflags=" -mmacosx-version-min=10.14"
-  export MACOSX_DEPLOYMENT_TARGET=10.14
+  export osxflags=" -mmacosx-version-min=10.13"
+  export MACOSX_DEPLOYMENT_TARGET=10.13
   export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
 else
   ovjBuildDir=`dirname "$(readlink -f $0))"`

--- a/bin/toolChain
+++ b/bin/toolChain
@@ -124,18 +124,28 @@ if [ ! -x /usr/bin/dpkg ]; then
     gsl-devel
     libXt-devel
     mesa-libGLU-devel
-    libX11-devel
    '
   i686List=' 
     libstdc++
     libstdc++-devel
+    libX11-devel
     glibc
     glibc-devel
    '
 
   if [ $version -ge 8 ]; then
+    if [[ ! -z $(type -t subscription-manager) ]] &&
+       [[ $rel = "redhat-release" ]]; then
+	if [[ $(subscription-manager repos --list-enabled |
+		grep -i codeready > /dev/null; echo $?) != 0 ]]; then
+          ARCH=$(/bin/arch)
+          subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms" &>> $logfile
+        fi
+        toolList="$toolList python3-scons"
+    else
      # Capitalization of PowerTools causes problems with 8.3
      yum -y --enablerepo=?ower?ools install python3-scons
+    fi
      toolList="$toolList libnsl motif-devel libglvnd-devel"
      i686List="$i686List libtirpc-devel"
   elif [ $version -ge 7 ]; then


### PR DESCRIPTION
Fixed toolChain to handle re-location of python3-scons on RHEL.
The libX11.i686 package is also needed